### PR TITLE
Add minimal Android port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# WikiArt Mobile
+
+This repository contains the original iOS project and an initial Android port.
+
+* `WikiArt3.0` – iOS application written in Swift.
+* `android` – Android port written in Kotlin.
+
+The Android port is minimal and serves as a starting point for further
+development.

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/app/build/
+.idea/

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,8 @@
+# WikiArt Android Port
+
+This is an initial Android port of WikiArt. The project includes a simple
+Kotlin-based application with a single activity and placeholder layout.
+
+To build the project, open the `android` directory in Android Studio or run
+`gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin
+plugin are installed).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        applicationId "com.wikiart"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.0"
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.wikiart" xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="WikiArt"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.wikiart
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/android/app/src/main/java/com/wikiart/Secrets.kt
+++ b/android/app/src/main/java/com/wikiart/Secrets.kt
@@ -1,0 +1,33 @@
+package com.wikiart
+
+object Secrets {
+    const val IS_OSS = false
+    const val FIELD_REPORT_EMAIL = "hello@email.com"
+
+    object Api {
+        object Client {
+            const val PRODUCTION = "deadbeef"
+            const val STAGING = "beefdead"
+        }
+
+        object Endpoint {
+            const val PRODUCTION = "www.wikiart.org"
+            const val STAGING = "www.wikiart.org"
+        }
+    }
+
+    object BasicHTTPAuth {
+        const val USERNAME = "usr"
+        const val PASSWORD = "pswd"
+    }
+
+    object CanvasPopKeys {
+        const val ACCESS_KEY = ""
+        const val SECRET_KEY = ""
+    }
+
+    object KiteKeys {
+        const val SECRET = ""
+        const val PUBLIC_KEY = ""
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/helloText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello WikiArt" />
+</LinearLayout>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'WikiArtAndroid'


### PR DESCRIPTION
## Summary
- introduce README overview of iOS and Android projects
- add basic Android application skeleton with Kotlin

## Testing
- `gradle tasks --all` *(fails: Could not resolve com.android.tools.build:gradle:8.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68490d863368832e871f55a3c6968b64