### PR TITLE
Expand Android port with paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WikiArt Mobile
 
-This repository contains the original iOS project and an initial Android port.
+This repository contains the original iOS project and an Android port.
 
 * `WikiArt3.0` – iOS application written in Swift.
 * `android` – Android port written in Kotlin.
 
-The Android port is minimal and serves as a starting point for further
-development.
+The Android port now displays a list of featured paintings retrieved from the
+WikiArt API with endless scrolling support powered by the Paging library.

--- a/android/README.md
+++ b/android/README.md
@@ -1,7 +1,9 @@
 # WikiArt Android Port
 
-This is an initial Android port of WikiArt. The project includes a simple
-Kotlin-based application with a single activity and placeholder layout.
+This is an Android port of WikiArt. The project now includes a RecyclerView
+based main activity that fetches a list of featured paintings from the
+WikiArt API using OkHttp and coroutines. Scrolling now loads additional
+pages automatically using the Paging library.
 
 To build the project, open the `android` directory in Android Studio or run
 `gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,4 +28,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'androidx.paging:paging-runtime:3.2.1'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.wikiart" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="WikiArt"
         android:allowBackup="true"

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -1,11 +1,31 @@
 package com.wikiart
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.cachedIn
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
+    private val adapter = PaintingAdapter()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val recyclerView: RecyclerView = findViewById(R.id.paintingRecyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        val repository = PaintingRepository()
+        lifecycleScope.launch {
+            repository.pagingFlow()
+                .cachedIn(lifecycleScope)
+                .collect { pagingData ->
+                    adapter.submitData(pagingData)
+                }
+        }
     }
 }

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -1,0 +1,40 @@
+package com.wikiart
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.PagingDataAdapter
+
+class PaintingAdapter : PagingDataAdapter<Painting, PaintingAdapter.PaintingViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.list_item_painting, parent, false)
+        return PaintingViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PaintingViewHolder, position: Int) {
+        getItem(position)?.let { holder.bind(it) }
+    }
+
+    class PaintingViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val titleText: TextView = itemView.findViewById(R.id.titleText)
+
+        fun bind(painting: Painting) {
+            titleText.text = painting.title
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Painting>() {
+            override fun areItemsTheSame(oldItem: Painting, newItem: Painting): Boolean =
+                oldItem.id == newItem.id
+
+            override fun areContentsTheSame(oldItem: Painting, newItem: Painting): Boolean =
+                oldItem == newItem
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -1,0 +1,20 @@
+package com.wikiart
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class PaintingRepository(private val service: WikiArtService = WikiArtService()) {
+    suspend fun getFeaturedPaintings(page: Int = 1): List<Painting> =
+        withContext(Dispatchers.IO) {
+            service.fetchFeaturedPaintings(page)?.paintings ?: emptyList()
+        }
+
+    fun pagingFlow(): Flow<PagingData<Painting>> =
+        Pager(PagingConfig(pageSize = 20)) {
+            WikiArtPagingSource(service)
+        }.flow
+}

--- a/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
@@ -1,0 +1,32 @@
+package com.wikiart
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+
+class WikiArtPagingSource(
+    private val service: WikiArtService
+) : PagingSource<Int, Painting>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
+        return try {
+            val page = params.key ?: 1
+            val result = service.fetchFeaturedPaintings(page)
+            val paintings = result?.paintings ?: emptyList()
+            val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
+            LoadResult.Page(
+                data = paintings,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Painting>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            state.closestPageToPosition(anchor)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchor)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -2,12 +2,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/helloText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello WikiArt" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/paintingRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/list_item_painting.xml
+++ b/android/app/src/main/res/layout/list_item_painting.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add paging-runtime dependency
- implement WikiArtPagingSource and repository flow
- update RecyclerView adapter to PagingDataAdapter
- hook paging flow up in MainActivity
- document Android paging capabilities

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849101ad5b0832ebcfa43a5d0e84837