### PR TITLE
Add category selection support on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the original iOS project and an Android port.
 * `WikiArt3.0` – iOS application written in Swift.
 * `android` – Android port written in Kotlin.
 
-The Android port now displays a list of featured paintings retrieved from the
-WikiArt API with endless scrolling support powered by the Paging library. List
-items load images using Coil, and tapping an item opens a simple detail screen.
+The Android port now displays paintings retrieved from the WikiArt API with
+endless scrolling support powered by the Paging library. A category spinner
+lets you filter paintings (e.g. Featured or Popular). List items load images
+using Coil, and tapping an item opens a simple detail screen.

--- a/android/README.md
+++ b/android/README.md
@@ -1,11 +1,12 @@
 # WikiArt Android Port
 
 This is an Android port of WikiArt. The project now includes a RecyclerView
-based main activity that fetches a list of featured paintings from the
-WikiArt API using OkHttp and coroutines. Scrolling now loads additional
-pages automatically using the Paging library. Each item displays the
-painting image using Coil and tapping a painting opens a detail screen
-showing a larger image and the title.
+based main activity that fetches paintings from the WikiArt API using OkHttp
+and coroutines. Scrolling now loads additional pages automatically using the
+Paging library. Each item displays the painting image using Coil and tapping a
+painting opens a detail screen showing a larger image and the title. A spinner
+at the top allows choosing a painting category and the list updates
+accordingly.
 
 To build the project, open the `android` directory in Android Studio or run
 `gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -2,11 +2,16 @@ package com.wikiart
 
 import android.os.Bundle
 import android.content.Intent
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.cachedIn
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
@@ -17,6 +22,9 @@ class MainActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
+    private val repository = PaintingRepository()
+    private var pagingJob: Job? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -25,9 +33,26 @@ class MainActivity : AppCompatActivity() {
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = adapter
 
-        val repository = PaintingRepository()
-        lifecycleScope.launch {
-            repository.pagingFlow()
+        val spinner: Spinner = findViewById(R.id.categorySpinner)
+        val categories = PaintingCategory.values()
+        spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, categories)
+
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                loadCategory(categories[position])
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+
+        // Load default category
+        loadCategory(PaintingCategory.FEATURED)
+    }
+
+    private fun loadCategory(category: PaintingCategory) {
+        pagingJob?.cancel()
+        pagingJob = lifecycleScope.launch {
+            repository.pagingFlow(category)
                 .cachedIn(lifecycleScope)
                 .collect { pagingData ->
                     adapter.submitData(pagingData)

--- a/android/app/src/main/java/com/wikiart/PaintingCategory.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingCategory.kt
@@ -8,4 +8,14 @@ enum class PaintingCategory {
     POPULAR,
     FEATURED,
     FAVORITES;
+
+    override fun toString(): String = when (this) {
+        MEDIA -> "Media"
+        STYLE -> "Style"
+        GENRE -> "Genre"
+        HIGH_RES -> "High Res"
+        POPULAR -> "Popular"
+        FEATURED -> "Featured"
+        FAVORITES -> "Favorites"
+    }
 }

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -8,13 +8,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class PaintingRepository(private val service: WikiArtService = WikiArtService()) {
-    suspend fun getFeaturedPaintings(page: Int = 1): List<Painting> =
+
+    suspend fun getPaintings(category: PaintingCategory, page: Int = 1): List<Painting> =
         withContext(Dispatchers.IO) {
-            service.fetchFeaturedPaintings(page)?.paintings ?: emptyList()
+            service.fetchPaintings(category, page)?.paintings ?: emptyList()
         }
 
-    fun pagingFlow(): Flow<PagingData<Painting>> =
+    fun pagingFlow(category: PaintingCategory): Flow<PagingData<Painting>> =
         Pager(PagingConfig(pageSize = 20)) {
-            WikiArtPagingSource(service)
+            WikiArtPagingSource(service, category)
         }.flow
 }

--- a/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
@@ -4,13 +4,14 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 
 class WikiArtPagingSource(
-    private val service: WikiArtService
+    private val service: WikiArtService,
+    private val category: PaintingCategory
 ) : PagingSource<Int, Painting>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
         return try {
             val page = params.key ?: 1
-            val result = service.fetchFeaturedPaintings(page)
+            val result = service.fetchPaintings(category, page)
             val paintings = result?.paintings ?: emptyList()
             val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
             LoadResult.Page(

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -11,8 +11,22 @@ class WikiArtService(
     private val client = OkHttpClient()
     private val gson = Gson()
 
-    fun fetchFeaturedPaintings(page: Int = 1): PaintingList? {
-        val url = serverConfig.apiBaseUrl.toString() + "/" + language + "?json=2&param=featured&page=" + page
+
+    fun fetchFeaturedPaintings(page: Int = 1): PaintingList? =
+        fetchPaintings(PaintingCategory.FEATURED, page)
+
+    fun fetchPaintings(category: PaintingCategory, page: Int = 1): PaintingList? {
+        val url = when (category) {
+            PaintingCategory.FEATURED ->
+                "${serverConfig.apiBaseUrl}/$language?json=2&param=featured&page=$page"
+            PaintingCategory.POPULAR ->
+                "${serverConfig.apiBaseUrl}/$language/popular-paintings/alltime?page=$page&json=2"
+            PaintingCategory.HIGH_RES ->
+                "${serverConfig.apiBaseUrl}/$language?json=2&param=high_resolution&page=$page"
+            else ->
+                "${serverConfig.apiBaseUrl}/$language?json=2&param=featured&page=$page"
+        }
+
         val request = Request.Builder().url(url).build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) return null

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -4,8 +4,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <Spinner
+        android:id="@+id/categorySpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/paintingRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add spinner UI to choose a painting category
- add string representation for `PaintingCategory`
- extend `WikiArtService` with `fetchPaintings` helper
- update paging source and repository to load by category
- adjust `MainActivity` to react to category changes
- document the new functionality in READMEs

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491bb2f664832e9bd9e455c332b249