### PR TITLE
Add search feature with autocomplete

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,5 +14,6 @@
             </intent-filter>
         </activity>
         <activity android:name=".PaintingDetailActivity" />
+        <activity android:name=".SearchActivity" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -2,6 +2,8 @@ package com.wikiart
 
 import android.os.Bundle
 import android.content.Intent
+import android.view.Menu
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -32,6 +34,21 @@ class MainActivity : AppCompatActivity() {
                 .collect { pagingData ->
                     adapter.submitData(pagingData)
                 }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_search -> {
+                startActivity(Intent(this, SearchActivity::class.java))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 }

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -17,4 +17,14 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         Pager(PagingConfig(pageSize = 20)) {
             WikiArtPagingSource(service)
         }.flow
+
+    suspend fun autoComplete(term: String): List<SearchAutoComplete> =
+        withContext(Dispatchers.IO) {
+            service.searchAutoComplete(term) ?: emptyList()
+        }
+
+    fun searchPagingFlow(term: String): Flow<PagingData<Painting>> =
+        Pager(PagingConfig(pageSize = 20)) {
+            SearchPagingSource(service, term)
+        }.flow
 }

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.os.Bundle
+import android.content.Intent
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -17,7 +18,7 @@ import kotlinx.coroutines.launch
 
 class SearchActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
-        val intent = android.content.Intent(this, PaintingDetailActivity::class.java)
+        val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
         intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
         startActivity(intent)

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -1,0 +1,82 @@
+package com.wikiart
+
+import android.os.Bundle
+import android.view.inputmethod.EditorInfo
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import android.text.TextWatcher
+import android.text.Editable
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.cachedIn
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class SearchActivity : AppCompatActivity() {
+    private val adapter = PaintingAdapter { painting ->
+        val intent = android.content.Intent(this, PaintingDetailActivity::class.java)
+        intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
+        intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
+        startActivity(intent)
+    }
+
+    private val repository = PaintingRepository()
+    private var searchJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_search)
+
+        val input: AutoCompleteTextView = findViewById(R.id.searchInput)
+        val recyclerView: RecyclerView = findViewById(R.id.resultsRecyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        val suggestions = ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line)
+        input.setAdapter(suggestions)
+
+        input.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                performSearch(input.text.toString())
+                true
+            } else {
+                false
+            }
+        }
+
+        input.setOnItemClickListener { _, _, position, _ ->
+            val term = suggestions.getItem(position) ?: return@setOnItemClickListener
+            performSearch(term)
+        }
+
+        input.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val text = s?.toString() ?: return
+                if (text.length >= 2) {
+                    lifecycleScope.launch {
+                        val autos = repository.autoComplete(text)
+                        suggestions.clear()
+                        suggestions.addAll(autos.map { it.label })
+                        suggestions.notifyDataSetChanged()
+                    }
+                }
+            }
+            override fun afterTextChanged(s: Editable?) {}
+        })
+    }
+
+    private fun performSearch(term: String) {
+        searchJob?.cancel()
+        searchJob = lifecycleScope.launch {
+            repository.searchPagingFlow(term)
+                .cachedIn(lifecycleScope)
+                .collectLatest { pagingData ->
+                    adapter.submitData(pagingData)
+                }
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/SearchAutoComplete.kt
+++ b/android/app/src/main/java/com/wikiart/SearchAutoComplete.kt
@@ -1,0 +1,11 @@
+package com.wikiart
+
+import com.google.gson.annotations.SerializedName
+
+data class SearchAutoComplete(
+    @SerializedName("Url") val url: String,
+    @SerializedName("Value") val value: String,
+    @SerializedName("Label") val label: String,
+    @SerializedName("Description") val description: String,
+    @SerializedName("Image") val image: String?
+)

--- a/android/app/src/main/java/com/wikiart/SearchPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/SearchPagingSource.kt
@@ -1,0 +1,33 @@
+package com.wikiart
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+
+class SearchPagingSource(
+    private val service: WikiArtService,
+    private val term: String
+) : PagingSource<Int, Painting>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
+        return try {
+            val page = params.key ?: 1
+            val result = service.searchPaintings(term, page)
+            val paintings = result?.paintings ?: emptyList()
+            val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
+            LoadResult.Page(
+                data = paintings,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Painting>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            state.closestPageToPosition(anchor)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchor)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -20,4 +20,26 @@ class WikiArtService(
             return gson.fromJson(body, PaintingList::class.java)
         }
     }
+
+    fun searchPaintings(term: String, page: Int = 1): PaintingList? {
+        val cleaned = java.net.URLEncoder.encode(term, "UTF-8")
+        val url = serverConfig.apiBaseUrl.toString() + "/" + language + "/Search/" + cleaned + "?json=2&pageSize=20&page=" + page
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            return gson.fromJson(body, PaintingList::class.java)
+        }
+    }
+
+    fun searchAutoComplete(term: String): List<SearchAutoComplete>? {
+        val url = serverConfig.apiBaseUrl.toString() + "/" + language + "/app/search/autocomplete/?term=" + java.net.URLEncoder.encode(term, "UTF-8")
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            val arr = gson.fromJson(body, Array<SearchAutoComplete>::class.java)
+            return arr.toList()
+        }
+    }
 }

--- a/android/app/src/main/res/layout/activity_search.xml
+++ b/android/app/src/main/res/layout/activity_search.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <AutoCompleteTextView
+        android:id="@+id/searchInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Search"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/resultsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+</LinearLayout>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_search"
+        android:title="Search"
+        android:icon="@android:drawable/ic_menu_search"
+        android:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
## Summary
- add `SearchActivity` with autocomplete suggestions and paging results
- query WikiArt search APIs from `WikiArtService`
- support search paging and autocomplete in repository
- integrate search button in `MainActivity`
- register new activity in manifest

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491bb3ec94832e8bd30efd1e2ccca9