### PR TITLE
Add artist detail screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,5 +16,6 @@
         <activity android:name=".PaintingDetailActivity" />
         <activity android:name=".SearchActivity" />
         <activity android:name=".FavoritesActivity" />
+        <activity android:name=".ArtistDetailActivity" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -1,0 +1,52 @@
+package com.wikiart
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import android.widget.TextView
+import android.widget.ImageView
+import coil.load
+import kotlinx.coroutines.launch
+import androidx.paging.PagingData
+
+class ArtistDetailActivity : AppCompatActivity() {
+    private val adapter = PaintingAdapter { painting ->
+        val intent = android.content.Intent(this, PaintingDetailActivity::class.java)
+        intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+        startActivity(intent)
+    }
+
+    private val repository = PaintingRepository()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_artist_detail)
+
+        val recycler: RecyclerView = findViewById(R.id.famousRecyclerView)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = adapter
+
+        val artistUrl = intent.getStringExtra(EXTRA_ARTIST_URL) ?: return
+        val artistName = intent.getStringExtra(EXTRA_ARTIST_NAME) ?: ""
+
+        findViewById<TextView>(R.id.artistName).text = artistName
+
+        lifecycleScope.launch {
+            val details = repository.getArtistDetails(artistUrl)
+            if (details != null) {
+                findViewById<TextView>(R.id.artistName).text = details.artistName
+                findViewById<TextView>(R.id.artistBio).text = details.biography
+                findViewById<ImageView>(R.id.artistImage).load(details.image)
+            }
+            val paintings = repository.getFamousPaintings(artistUrl)
+            adapter.submitData(PagingData.from(paintings))
+        }
+    }
+
+    companion object {
+        const val EXTRA_ARTIST_URL = "extra_artist_url"
+        const val EXTRA_ARTIST_NAME = "extra_artist_name"
+    }
+}

--- a/android/app/src/main/java/com/wikiart/ArtistDetails.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetails.kt
@@ -1,0 +1,13 @@
+package com.wikiart
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class ArtistDetails(
+    @SerializedName("artistName") val artistName: String?,
+    @SerializedName("biography") val biography: String?,
+    @SerializedName("birthDayAsString") val birth: String?,
+    @SerializedName("deathDayAsString") val death: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("url") val url: String?
+) : Serializable

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -6,6 +6,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Button
 import android.widget.Toast
+import android.content.Intent
 import coil.load
 import androidx.lifecycle.lifecycleScope
 import com.wikiart.data.FavoritesRepository
@@ -23,6 +24,17 @@ class PaintingDetailActivity : AppCompatActivity() {
 
         findViewById<TextView>(R.id.detailTitle).text = title
         findViewById<ImageView>(R.id.detailImage).load(imageUrl)
+
+        val artistNameView: TextView = findViewById(R.id.detailArtist)
+        val artistName = painting?.artistName
+        artistNameView.text = artistName
+        artistNameView.setOnClickListener {
+            val url = painting?.artistUrl ?: return@setOnClickListener
+            val intent = Intent(this, ArtistDetailActivity::class.java)
+            intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, url)
+            intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artistName)
+            startActivity(intent)
+        }
 
         val favoriteButton: Button = findViewById(R.id.favoriteButton)
         val repo = FavoritesRepository(this)
@@ -54,5 +66,7 @@ class PaintingDetailActivity : AppCompatActivity() {
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_IMAGE = "extra_image"
         const val EXTRA_PAINTING = "extra_painting"
+        const val EXTRA_ARTIST_URL = "extra_artist_url"
+        const val EXTRA_ARTIST_NAME = "extra_artist_name"
     }
 }

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -38,4 +38,14 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         withContext(Dispatchers.IO) {
             service.fetchSections(category) ?: emptyList()
         }
+
+    suspend fun getArtistDetails(path: String): ArtistDetails? =
+        withContext(Dispatchers.IO) {
+            service.fetchArtistDetails(path)
+        }
+
+    suspend fun getFamousPaintings(path: String): List<Painting> =
+        withContext(Dispatchers.IO) {
+            service.fetchFamousPaintings(path)?.paintings ?: emptyList()
+        }
 }

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -69,6 +69,26 @@ class WikiArtService(
         }
     }
 
+    fun fetchArtistDetails(path: String): ArtistDetails? {
+        val url = "${serverConfig.apiBaseUrl}$path?json=2"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            return gson.fromJson(body, ArtistDetails::class.java)
+        }
+    }
+
+    fun fetchFamousPaintings(path: String, page: Int = 1): PaintingList? {
+        val url = "${serverConfig.apiBaseUrl}$path/mode/featured?page=$page&json=2"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            return gson.fromJson(body, PaintingList::class.java)
+        }
+    }
+
     fun fetchSections(category: PaintingCategory): List<PaintingSection>? {
         val group = when (category) {
             PaintingCategory.MEDIA -> 12

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -10,31 +10,28 @@
         android:padding="16dp">
 
         <ImageView
-            android:id="@+id/detailImage"
+            android:id="@+id/artistImage"
             android:layout_width="match_parent"
-            android:layout_height="300dp"
+            android:layout_height="200dp"
             android:scaleType="centerCrop" />
 
         <TextView
-            android:id="@+id/detailTitle"
+            android:id="@+id/artistName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
         <TextView
-            android:id="@+id/detailArtist"
+            android:id="@+id/artistBio"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textColor="@android:color/holo_blue_dark"
-            android:textStyle="bold" />
+            android:layout_marginTop="8dp" />
 
-        <Button
-            android:id="@+id/favoriteButton"
-            android:layout_width="wrap_content"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/famousRecyclerView"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/add_favorite" />
+            android:nestedScrollingEnabled="false" />
     </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="remove_favorite">Remove Favorite</string>
     <string name="added_favorite">Added to favorites</string>
     <string name="removed_favorite">Removed from favorites</string>
+    <string name="famous_works">Famous Works</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `ArtistDetailActivity` to show artist bio and famous works
- expose new API calls in `WikiArtService` for artist details and famous paintings
- wire repository helpers for artist data
- link artist name in `PaintingDetailActivity` to navigate
- update layouts and manifest for the new screen

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684925f1e32c832e8c9568d12ec8501b