### PR TITLE
Add share and buy actions with related paintings

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,5 +16,6 @@
         <activity android:name=".PaintingDetailActivity" />
         <activity android:name=".SearchActivity" />
         <activity android:name=".FavoritesActivity" />
+        <activity android:name=".StoreActivity" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -31,9 +31,22 @@ class PaintingDetailActivity : AppCompatActivity() {
         findViewById<ImageView>(R.id.detailImage).load(imageUrl)
 
         painting?.let {
-            findViewById<TextView>(R.id.detailYear).text = getString(R.string.year, it.year)
-            findViewById<TextView>(R.id.detailDimensions).text =
-                getString(R.string.dimensions, it.width, it.height)
+            val yearView: TextView = findViewById(R.id.detailYear)
+            val dimView: TextView = findViewById(R.id.detailDimensions)
+
+            if (it.year.isNotBlank()) {
+                yearView.text = getString(R.string.year, it.year)
+                yearView.visibility = View.VISIBLE
+            } else {
+                yearView.visibility = View.GONE
+            }
+
+            if (it.width > 0 && it.height > 0) {
+                dimView.text = getString(R.string.dimensions, it.width, it.height)
+                dimView.visibility = View.VISIBLE
+            } else {
+                dimView.visibility = View.GONE
+            }
         }
 
         val favoriteButton: Button = findViewById(R.id.favoriteButton)
@@ -80,6 +93,7 @@ class PaintingDetailActivity : AppCompatActivity() {
         }
 
         val relatedRecycler: RecyclerView = findViewById(R.id.relatedRecyclerView)
+        val relatedTitle: TextView = findViewById(R.id.relatedTitle)
         val relatedAdapter = RelatedPaintingAdapter { selected ->
             val intent = Intent(this, PaintingDetailActivity::class.java)
             intent.putExtra(EXTRA_PAINTING, selected)
@@ -93,6 +107,10 @@ class PaintingDetailActivity : AppCompatActivity() {
                 val related = repository.getRelatedPaintings(it.paintingUrl)
                 if (related.isNotEmpty()) {
                     relatedAdapter.submitList(related)
+                    relatedTitle.visibility = View.VISIBLE
+                }
+                else {
+                    relatedTitle.visibility = View.GONE
                 }
             }
         }

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -28,4 +28,9 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         Pager(PagingConfig(pageSize = 20)) {
             SearchPagingSource(service, term)
         }.flow
+
+    suspend fun getRelatedPaintings(path: String): List<Painting> =
+        withContext(Dispatchers.IO) {
+            service.fetchRelatedPaintings(path)?.paintings ?: emptyList()
+        }
 }

--- a/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
@@ -1,0 +1,45 @@
+package com.wikiart
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+
+class RelatedPaintingAdapter(
+    private val onItemClick: (Painting) -> Unit = {}
+) : RecyclerView.Adapter<RelatedPaintingAdapter.ViewHolder>() {
+
+    private val items = mutableListOf<Painting>()
+
+    fun submitList(list: List<Painting>) {
+        items.clear()
+        items.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_related_painting, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val image: ImageView = itemView.findViewById(R.id.paintingImage)
+        private val title: TextView = itemView.findViewById(R.id.titleText)
+
+        fun bind(painting: Painting) {
+            title.text = painting.title
+            image.load(painting.image)
+            itemView.setOnClickListener { onItemClick(painting) }
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
@@ -10,15 +10,7 @@ import coil.load
 
 class RelatedPaintingAdapter(
     private val onItemClick: (Painting) -> Unit = {}
-) : RecyclerView.Adapter<RelatedPaintingAdapter.ViewHolder>() {
-
-    private val items = mutableListOf<Painting>()
-
-    fun submitList(list: List<Painting>) {
-        items.clear()
-        items.addAll(list)
-        notifyDataSetChanged()
-    }
+) : androidx.recyclerview.widget.ListAdapter<Painting, RelatedPaintingAdapter.ViewHolder>(Diff()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -27,10 +19,8 @@ class RelatedPaintingAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(items[position])
+        holder.bind(getItem(position))
     }
-
-    override fun getItemCount(): Int = items.size
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val image: ImageView = itemView.findViewById(R.id.paintingImage)
@@ -41,5 +31,10 @@ class RelatedPaintingAdapter(
             image.load(painting.image)
             itemView.setOnClickListener { onItemClick(painting) }
         }
+    }
+
+    private class Diff : androidx.recyclerview.widget.DiffUtil.ItemCallback<Painting>() {
+        override fun areItemsTheSame(oldItem: Painting, newItem: Painting): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Painting, newItem: Painting): Boolean = oldItem == newItem
     }
 }

--- a/android/app/src/main/java/com/wikiart/StoreActivity.kt
+++ b/android/app/src/main/java/com/wikiart/StoreActivity.kt
@@ -1,0 +1,28 @@
+package com.wikiart
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+
+class StoreActivity : AppCompatActivity() {
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_store)
+
+        val webView: WebView = findViewById(R.id.storeWebView)
+        webView.settings.javaScriptEnabled = true
+        webView.webViewClient = WebViewClient()
+
+        val imageUrl = intent.getStringExtra(EXTRA_IMAGE_URL) ?: ""
+        val url = "https://www.canvaspop.com/upload?imageUrl=$imageUrl"
+        webView.loadUrl(url)
+    }
+
+    companion object {
+        const val EXTRA_IMAGE_URL = "extra_image_url"
+    }
+}

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -56,4 +56,15 @@ class WikiArtService(
             return arr.toList()
         }
     }
+
+    fun fetchRelatedPaintings(path: String): PaintingList? {
+        val cleanPath = if (path.startsWith("http")) path else "${serverConfig.apiBaseUrl}$path"
+        val url = "$cleanPath?json=2"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            return gson.fromJson(body, PaintingList::class.java)
+        }
+    }
 }

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -22,11 +22,52 @@
             android:layout_marginTop="8dp"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
+        <TextView
+            android:id="@+id/detailYear"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp" />
+
+        <TextView
+            android:id="@+id/detailDimensions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp" />
+
         <Button
             android:id="@+id/favoriteButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:text="@string/add_favorite" />
+
+        <Button
+            android:id="@+id/shareButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/share" />
+
+        <Button
+            android:id="@+id/buyButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/buy" />
+
+        <TextView
+            android:id="@+id/relatedTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/related_paintings"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/relatedRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:scrollbars="horizontal" />
     </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -26,13 +26,15 @@
             android:id="@+id/detailYear"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp" />
+            android:layout_marginTop="4dp"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/detailDimensions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="2dp" />
+            android:layout_marginTop="2dp"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/favoriteButton"
@@ -61,7 +63,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/related_paintings"
-            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:visibility="gone" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/relatedRecyclerView"

--- a/android/app/src/main/res/layout/activity_store.xml
+++ b/android/app/src/main/res/layout/activity_store.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/storeWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
     <string name="remove_favorite">Remove Favorite</string>
     <string name="added_favorite">Added to favorites</string>
     <string name="removed_favorite">Removed from favorites</string>
+    <string name="share">Share</string>
+    <string name="buy">Buy</string>
+    <string name="year">Year: %1$s</string>
+    <string name="dimensions">Dimensions: %1$dx%2$d</string>
+    <string name="related_paintings">Related Paintings</string>
 </resources>


### PR DESCRIPTION
## Summary
- add share/buy buttons, year & dimensions
- show related paintings horizontally
- support opening share intent and CanvasPop web view
- implement related painting API calls

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684922ddb5fc832e8601e8d1519d17ba