### PR TITLE
Add support and full image features to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ This repository contains the original iOS project and an Android port.
 The Android port now displays paintings retrieved from the WikiArt API with
 endless scrolling support powered by the Paging library. A category spinner
 lets you filter paintings (e.g. Featured or Popular). List items load images
-using Coil, and tapping an item opens a simple detail screen.
+using Coil, and tapping an item opens a detail screen. You can search with
+autocomplete suggestions, mark paintings as favourites, view artist details and
+share or buy prints of a painting. Images can also be viewed full screen with
+pinch‑to‑zoom and a Support screen provides links to send feedback or make a
+donation.

--- a/android/README.md
+++ b/android/README.md
@@ -5,8 +5,10 @@ based main activity that fetches paintings from the WikiArt API using OkHttp
 and coroutines. Scrolling now loads additional pages automatically using the
 Paging library. Each item displays the painting image using Coil and tapping a
 painting opens a detail screen showing a larger image and the title. A spinner
-at the top allows choosing a painting category and the list updates
-accordingly.
+at the top allows choosing a painting category and the list updates accordingly.
+Additional screens let you search with autocomplete, manage favourites and view
+artist information. You can share or buy prints of a painting, view the image in
+full screen and visit a Support screen to send feedback or make a donation.
 
 To build the project, open the `android` directory in Android Studio or run
 `gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'androidx.paging:paging-runtime:3.2.1'
     implementation 'io.coil-kt:coil:2.5.0'
+    implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation "androidx.room:room-runtime:2.6.1"
     kapt "androidx.room:room-compiler:2.6.1"
     implementation "androidx.room:room-ktx:2.6.1"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,8 +18,9 @@
         <activity android:name=".FavoritesActivity" />
 
         <activity android:name=".StoreActivity" />
-
+        <activity android:name=".ImageDetailActivity" />
         <activity android:name=".ArtistDetailActivity" />
+        <activity android:name=".SupportActivity" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
@@ -1,0 +1,22 @@
+package com.wikiart
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import coil.load
+import com.github.chrisbanes.photoview.PhotoView
+
+class ImageDetailActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_image_detail)
+
+        val url = intent.getStringExtra(EXTRA_IMAGE_URL) ?: ""
+        val imageView: PhotoView = findViewById(R.id.fullImageView)
+        imageView.load(url)
+        imageView.setOnClickListener { finish() }
+    }
+
+    companion object {
+        const val EXTRA_IMAGE_URL = "extra_image_url"
+    }
+}

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.paging.cachedIn
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.wikiart.model.PaintingSection
+import com.wikiart.SupportActivity
 
 class MainActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
@@ -105,6 +106,10 @@ class MainActivity : AppCompatActivity() {
             }
             R.id.action_favorites -> {
                 startActivity(Intent(this, FavoritesActivity::class.java))
+                true
+            }
+            R.id.action_support -> {
+                startActivity(Intent(this, SupportActivity::class.java))
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -7,7 +7,8 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Button
 import android.widget.Toast
-import android.content.Intent
+import android.view.View
+import com.wikiart.ImageDetailActivity
 import coil.load
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -29,7 +30,13 @@ class PaintingDetailActivity : AppCompatActivity() {
         val imageUrl = painting?.image ?: intent.getStringExtra(EXTRA_IMAGE) ?: ""
 
         findViewById<TextView>(R.id.detailTitle).text = title
-        findViewById<ImageView>(R.id.detailImage).load(imageUrl)
+        val detailImage: ImageView = findViewById(R.id.detailImage)
+        detailImage.load(imageUrl)
+        detailImage.setOnClickListener {
+            val intent = Intent(this, ImageDetailActivity::class.java)
+            intent.putExtra(ImageDetailActivity.EXTRA_IMAGE_URL, imageUrl)
+            startActivity(intent)
+        }
 
 
         painting?.let {

--- a/android/app/src/main/java/com/wikiart/SupportActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SupportActivity.kt
@@ -1,0 +1,27 @@
+package com.wikiart
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+
+class SupportActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_support)
+
+        findViewById<Button>(R.id.feedbackButton).setOnClickListener {
+            val intent = Intent(Intent.ACTION_SENDTO).apply {
+                data = Uri.parse("mailto:wikiartfeedback@icloud.com")
+            }
+            startActivity(intent)
+        }
+
+        findViewById<Button>(R.id.donateButton).setOnClickListener {
+            val intent = Intent(Intent.ACTION_VIEW,
+                Uri.parse("https://www.buymeacoffee.com/wikiart"))
+            startActivity(intent)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.github.chrisbanes.photoview.PhotoView
+        android:id="@+id/fullImageView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitCenter"/>
+</FrameLayout>

--- a/android/app/src/main/res/layout/activity_support.xml
+++ b/android/app/src/main/res/layout/activity_support.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/feedbackButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/send_feedback"/>
+
+    <Button
+        android:id="@+id/donateButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/donate"
+        android:layout_marginTop="12dp"/>
+</LinearLayout>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-
         android:id="@+id/action_search"
         android:title="Search"
         android:icon="@android:drawable/ic_menu_search"
         android:showAsAction="ifRoom" />
 
+    <item
         android:id="@+id/action_favorites"
         android:title="@string/favorites"
         android:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_support"
+        android:title="@string/support"
+        android:showAsAction="never" />
 
 </menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,4 +14,8 @@
 
     <string name="famous_works">Famous Works</string>
 
+    <string name="support">Support</string>
+    <string name="send_feedback">Send Feedback</string>
+    <string name="donate">Donate</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- allow viewing painting images full screen with pinch-zoom
- add a simple Support screen with feedback and donation actions
- expose Support screen in the menu and update menu XML
- hook up Support and Image Detail activities in the manifest
- document the expanded Android app features

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a1a2d64832eb14ec59f8353dd64