### PR TITLE
Add Android artists browser

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity android:name=".ImageDetailActivity" />
         <activity android:name=".ArtistDetailActivity" />
         <activity android:name=".SupportActivity" />
+        <activity android:name=".ArtistsActivity" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
@@ -1,0 +1,48 @@
+package com.wikiart
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.wikiart.model.Artist
+
+class ArtistAdapter(
+    private val onItemClick: (Artist) -> Unit = {}
+) : PagingDataAdapter<Artist, ArtistAdapter.ArtistViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArtistViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.list_item_artist, parent, false)
+        return ArtistViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ArtistViewHolder, position: Int) {
+        getItem(position)?.let { holder.bind(it) }
+    }
+
+    inner class ArtistViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val nameText: TextView = itemView.findViewById(R.id.artistName)
+        private val artistImage: ImageView = itemView.findViewById(R.id.artistImage)
+
+        fun bind(artist: Artist) {
+            nameText.text = artist.title
+            artistImage.load(artist.image)
+            itemView.setOnClickListener { onItemClick(artist) }
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Artist>() {
+            override fun areItemsTheSame(oldItem: Artist, newItem: Artist): Boolean =
+                oldItem.id == newItem.id
+
+            override fun areContentsTheSame(oldItem: Artist, newItem: Artist): Boolean =
+                oldItem == newItem
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -1,0 +1,87 @@
+package com.wikiart
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.paging.cachedIn
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.wikiart.model.ArtistCategory
+import com.wikiart.model.ArtistSection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+class ArtistsActivity : AppCompatActivity() {
+    private val adapter = ArtistAdapter { artist ->
+        val intent = Intent(this, ArtistDetailActivity::class.java)
+        intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, artist.artistUrl)
+        intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artist.title)
+        startActivity(intent)
+    }
+
+    private val repository = PaintingRepository()
+    private var pagingJob: Job? = null
+    private var currentSection: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_artists)
+
+        val recycler: RecyclerView = findViewById(R.id.artistRecyclerView)
+        recycler.layoutManager = GridLayoutManager(this, 2)
+        recycler.adapter = adapter
+
+        val spinner: Spinner = findViewById(R.id.artistCategorySpinner)
+        val categories = ArtistCategory.values()
+        spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, categories)
+
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                val category = categories[position]
+                if (category.hasSections()) {
+                    lifecycleScope.launch {
+                        val sections = repository.artistSections(category)
+                        if (sections.isNotEmpty()) {
+                            showSectionDialog(category, sections)
+                        }
+                    }
+                } else {
+                    currentSection = null
+                    loadCategory(category)
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+
+        loadCategory(ArtistCategory.POPULAR)
+    }
+
+    private fun loadCategory(category: ArtistCategory) {
+        pagingJob?.cancel()
+        pagingJob = lifecycleScope.launch {
+            repository.artistsPagingFlow(category, currentSection)
+                .cachedIn(lifecycleScope)
+                .collect { pagingData ->
+                    adapter.submitData(pagingData)
+                }
+        }
+    }
+
+    private fun showSectionDialog(category: ArtistCategory, sections: List<ArtistSection>) {
+        val names = sections.map { it.title }.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle(category.toString())
+            .setItems(names) { _, which ->
+                currentSection = sections[which].url
+                loadCategory(category)
+            }
+            .show()
+    }
+}

--- a/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
@@ -1,0 +1,36 @@
+package com.wikiart
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.wikiart.model.Artist
+import com.wikiart.model.ArtistCategory
+
+class ArtistsPagingSource(
+    private val service: WikiArtService,
+    private val category: ArtistCategory,
+    private val section: String? = null
+) : PagingSource<Int, Artist>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Artist> {
+        return try {
+            val page = params.key ?: 1
+            val result = service.fetchArtists(category, page, section)
+            val artists = result?.artists ?: emptyList()
+            val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
+            LoadResult.Page(
+                data = artists,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Artist>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            state.closestPageToPosition(anchor)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchor)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -112,6 +112,10 @@ class MainActivity : AppCompatActivity() {
                 startActivity(Intent(this, SupportActivity::class.java))
                 true
             }
+            R.id.action_artists -> {
+                startActivity(Intent(this, ArtistsActivity::class.java))
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.wikiart.model.PaintingSection
+import com.wikiart.model.Artist
+import com.wikiart.model.ArtistCategory
+import com.wikiart.model.ArtistSection
 
 class PaintingRepository(private val service: WikiArtService = WikiArtService()) {
 
@@ -52,5 +55,15 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
     suspend fun getFamousPaintings(path: String): List<Painting> =
         withContext(Dispatchers.IO) {
             service.fetchFamousPaintings(path)?.paintings ?: emptyList()
+        }
+
+    fun artistsPagingFlow(category: ArtistCategory, section: String? = null): Flow<PagingData<Artist>> =
+        Pager(PagingConfig(pageSize = 20)) {
+            ArtistsPagingSource(service, category, section)
+        }.flow
+
+    suspend fun artistSections(category: ArtistCategory): List<ArtistSection> =
+        withContext(Dispatchers.IO) {
+            service.fetchArtistSections(category) ?: emptyList()
         }
 }

--- a/android/app/src/main/java/com/wikiart/model/Artist.kt
+++ b/android/app/src/main/java/com/wikiart/model/Artist.kt
@@ -1,0 +1,17 @@
+package com.wikiart.model
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+/**
+ * Basic artist information returned from the API.
+ */
+data class Artist(
+    @SerializedName("id") val id: String?,
+    @SerializedName("title") val title: String?,
+    @SerializedName("year") val year: String?,
+    @SerializedName("nation") val nation: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("artistUrl") val artistUrl: String?,
+    @SerializedName("totalWorksTitle") val totalWorksTitle: String?
+) : Serializable

--- a/android/app/src/main/java/com/wikiart/model/ArtistCategory.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistCategory.kt
@@ -1,0 +1,37 @@
+package com.wikiart.model
+
+/**
+ * Categories for browsing artists.
+ * Mirrors the iOS ArtistCategory enum.
+ */
+enum class ArtistCategory(val path: String, private val hasSections: Boolean) {
+    ALPHABETICAL("Alphabet", false),
+    ART_MOVEMENT("artists-by-Art-Movement", true),
+    SCHOOL("artists-by-painting-school", true),
+    GENRE("artists-by-genre", true),
+    FIELD("artists-by-field", true),
+    NATION("artists-by-nation", true),
+    CENTURIES("artists-by-century", true),
+    CHRONOLOGY("chronological-artists", false),
+    POPULAR("popular-artists", false),
+    FEMALE("female-artists", false),
+    RECENT("recently-added-artists", false),
+    INSTITUTIONS("artists-by-art-institution", true);
+
+    fun hasSections(): Boolean = hasSections
+
+    override fun toString(): String = when (this) {
+        ALPHABETICAL -> "Alphabet"
+        ART_MOVEMENT -> "Art Movement"
+        SCHOOL -> "Painting School"
+        GENRE -> "Genre"
+        FIELD -> "Field"
+        NATION -> "Nation"
+        CENTURIES -> "Century"
+        CHRONOLOGY -> "Chronological"
+        POPULAR -> "Popular"
+        FEMALE -> "Female"
+        RECENT -> "Recent"
+        INSTITUTIONS -> "Art Institution"
+    }
+}

--- a/android/app/src/main/java/com/wikiart/model/ArtistSection.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistSection.kt
@@ -1,0 +1,22 @@
+package com.wikiart.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a grouping within an artist category.
+ */
+data class ArtistSection(
+    @SerializedName("CategoryId") val categoryId: CategoryId,
+    @SerializedName("Url") val url: String,
+    @SerializedName("Title") val title: String,
+    @SerializedName("Count") val count: Int
+) {
+    data class CategoryId(@SerializedName("_oid") val oid: String)
+}
+
+/** Wrapper for the API response. */
+data class ArtistSectionsResponse(
+    @SerializedName("DictionariesWithCategories") val dictionaries: Map<String, List<ArtistSection>>
+) {
+    val items: List<ArtistSection> get() = dictionaries.values.flatten()
+}

--- a/android/app/src/main/java/com/wikiart/model/ArtistsList.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistsList.kt
@@ -1,0 +1,15 @@
+package com.wikiart.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * API response containing a paginated list of artists and optional paintings.
+ */
+data class ArtistsList(
+    @SerializedName("Artists") val artists: List<Artist>,
+    @SerializedName("AllArtistsCount") val allArtistsCount: Int,
+    @SerializedName("PageSize") val pageSize: Int?
+) {
+    val pageCount: Int
+        get() = if (pageSize != null && pageSize > 0) (allArtistsCount / pageSize) + 1 else 1
+}

--- a/android/app/src/main/res/layout/activity_artists.xml
+++ b/android/app/src/main/res/layout/activity_artists.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Spinner
+        android:id="@+id/artistCategorySpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/artistRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/list_item_artist.xml
+++ b/android/app/src/main/res/layout/list_item_artist.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/artistImage"
+        android:layout_width="match_parent"
+        android:layout_height="150dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/artistName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+</LinearLayout>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -16,4 +16,9 @@
         android:title="@string/support"
         android:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_artists"
+        android:title="@string/artists"
+        android:showAsAction="never" />
+
 </menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -17,5 +17,6 @@
     <string name="support">Support</string>
     <string name="send_feedback">Send Feedback</string>
     <string name="donate">Donate</string>
+    <string name="artists">Artists</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- implement Artist model data classes and paging source
- add WikiArtService calls for artist sections and lists
- provide repository helpers for artists
- add ArtistsActivity with grid layout and ArtistAdapter
- update menu and strings for new artists screen
- register ArtistsActivity in manifest

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492d1c54b0832eb46026529eff2e2a