### PR TITLE
Add Google Play Billing purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ lets you filter paintings (e.g. Featured or Popular). List items load images
 using Coil, and tapping an item opens a detail screen. You can search with
 autocomplete suggestions, mark paintings as favourites, view artist details and
 share or buy prints of a painting. Images can also be viewed full screen with
-pinch‑to‑zoom and a Support screen provides links to send feedback or make a
-donation.
+pinch‑to‑zoom and a Support screen lets you send feedback or donate via
+Google Play in‑app purchases.

--- a/android/README.md
+++ b/android/README.md
@@ -8,8 +8,11 @@ painting opens a detail screen showing a larger image and the title. A spinner
 at the top allows choosing a painting category and the list updates accordingly.
 Additional screens let you search with autocomplete, manage favourites and view
 artist information. You can share or buy prints of a painting, view the image in
-full screen and visit a Support screen to send feedback or make a donation.
+full screen and visit a Support screen to send feedback or make a donation
+using Google Play Billing.
 
 To build the project, open the `android` directory in Android Studio or run
 `gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin
-plugin are installed).
+plugin are installed). To test the billing flow you must sign in with a Google
+Play test account on your device and upload the in-app products in the Play
+Console.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,4 +37,5 @@ dependencies {
     implementation "androidx.room:room-runtime:2.6.1"
     kapt "androidx.room:room-compiler:2.6.1"
     implementation "androidx.room:room-ktx:2.6.1"
+    implementation 'com.android.billingclient:billing-ktx:6.1.0'
 }

--- a/android/app/src/main/java/com/wikiart/SupportActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SupportActivity.kt
@@ -4,12 +4,40 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Button
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.android.billingclient.api.QueryProductDetailsParams
 
-class SupportActivity : AppCompatActivity() {
+class SupportActivity : AppCompatActivity(), PurchasesUpdatedListener {
+
+    private lateinit var billingClient: BillingClient
+    private val productIds = listOf(
+        "wikiart.support4",
+        "wiki.level3",
+        "wikiart.level2",
+        "wikiart.support1",
+        "generous"
+    )
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_support)
+
+        billingClient = BillingClient.newBuilder(this)
+            .enablePendingPurchases()
+            .setListener(this)
+            .build()
+        billingClient.startConnection(object : BillingClientStateListener {
+            override fun onBillingSetupFinished(result: BillingResult) {}
+            override fun onBillingServiceDisconnected() {}
+        })
 
         findViewById<Button>(R.id.feedbackButton).setOnClickListener {
             val intent = Intent(Intent.ACTION_SENDTO).apply {
@@ -19,9 +47,80 @@ class SupportActivity : AppCompatActivity() {
         }
 
         findViewById<Button>(R.id.donateButton).setOnClickListener {
-            val intent = Intent(Intent.ACTION_VIEW,
-                Uri.parse("https://www.buymeacoffee.com/wikiart"))
-            startActivity(intent)
+            queryProductsAndShowDialog()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        billingClient.endConnection()
+    }
+
+    private fun queryProductsAndShowDialog() {
+        val products = productIds.map {
+            QueryProductDetailsParams.Product.newBuilder()
+                .setProductId(it)
+                .setProductType(BillingClient.ProductType.INAPP)
+                .build()
+        }
+
+        val params = QueryProductDetailsParams.newBuilder()
+            .setProductList(products)
+            .build()
+
+        billingClient.queryProductDetailsAsync(params) { result, list ->
+            if (result.responseCode == BillingClient.BillingResponseCode.OK && list.isNotEmpty()) {
+                showProductDialog(list)
+            } else {
+                Toast.makeText(this, "Unable to load products", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun showProductDialog(details: List<ProductDetails>) {
+        val sorted = details.sortedByDescending {
+            it.oneTimePurchaseOfferDetails?.priceAmountMicros ?: 0
+        }
+        val names = sorted.map {
+            "${it.title} ${it.oneTimePurchaseOfferDetails?.formattedPrice ?: ""}"
+        }
+        val builder = androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(getString(R.string.support))
+            .setItems(names.toTypedArray()) { _, which ->
+                launchPurchase(sorted[which])
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+        builder.show()
+    }
+
+    private fun launchPurchase(details: ProductDetails) {
+        val flowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(
+                listOf(
+                    BillingFlowParams.ProductDetailsParams.newBuilder()
+                        .setProductDetails(details)
+                        .build()
+                )
+            )
+            .build()
+        billingClient.launchBillingFlow(this, flowParams)
+    }
+
+    override fun onPurchasesUpdated(result: BillingResult, purchases: MutableList<Purchase>?) {
+        if (result.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+            for (purchase in purchases) {
+                handlePurchase(purchase)
+            }
+        }
+    }
+
+    private fun handlePurchase(purchase: Purchase) {
+        if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED && !purchase.isAcknowledged) {
+            val params = AcknowledgePurchaseParams.newBuilder()
+                .setPurchaseToken(purchase.purchaseToken)
+                .build()
+            billingClient.acknowledgePurchase(params) {}
+            Toast.makeText(this, R.string.thank_you, Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="support">Support</string>
     <string name="send_feedback">Send Feedback</string>
     <string name="donate">Donate</string>
+    <string name="thank_you">Thank you for your support!</string>
     <string name="artists">Artists</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- integrate Google Play Billing dependency
- hook SupportActivity into BillingClient and present products for purchase
- acknowledge successful purchases and show a toast
- document the billing setup in the READMEs

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492ec852a8832e94cf144fb7437b10