### PR TITLE
Fix page count formula and add Kotlin tests

### DIFF
--- a/WikiArt3.0/Models/PaintingList.swift
+++ b/WikiArt3.0/Models/PaintingList.swift
@@ -29,7 +29,7 @@ class PaintingList: Codable {
 extension PaintingList {
     
     var pageCount: Int {
-        return (allPaintingsCount / pageSize) + 1
+        return (allPaintingsCount + pageSize - 1) / pageSize
     }
     
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,4 +38,5 @@ dependencies {
     kapt "androidx.room:room-compiler:2.6.1"
     implementation "androidx.room:room-ktx:2.6.1"
     implementation 'com.android.billingclient:billing-ktx:6.1.0'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/app/src/main/java/com/wikiart/PaintingList.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingList.kt
@@ -8,5 +8,5 @@ data class PaintingList(
     @SerializedName("PageSize") val pageSize: Int
 ) {
     val pageCount: Int
-        get() = (allPaintingsCount / pageSize) + 1
+        get() = (allPaintingsCount + pageSize - 1) / pageSize
 }

--- a/android/app/src/test/java/com/wikiart/PaintingListTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingListTest.kt
@@ -1,0 +1,22 @@
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PaintingListTest {
+    @Test
+    fun pageCountHandlesZeroPaintings() {
+        val list = PaintingList(emptyList(), allPaintingsCount = 0, pageSize = 5)
+        assertEquals(0, list.pageCount)
+    }
+
+    @Test
+    fun pageCountExactMultiple() {
+        val list = PaintingList(emptyList(), allPaintingsCount = 10, pageSize = 5)
+        assertEquals(2, list.pageCount)
+    }
+
+    @Test
+    fun pageCountRoundsUp() {
+        val list = PaintingList(emptyList(), allPaintingsCount = 9, pageSize = 5)
+        assertEquals(2, list.pageCount)
+    }
+}


### PR DESCRIPTION
## Summary
- correct page count formula on iOS and Android
- include JUnit dependency for unit tests
- add PaintingListTest with edge case coverage

## Testing
- `gradle -p android test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684931ae15a8832e90641b8fbf199455