### PR TITLE
Fix artist page count rounding

### DIFF
--- a/android/app/src/main/java/com/wikiart/model/ArtistsList.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistsList.kt
@@ -11,5 +11,5 @@ data class ArtistsList(
     @SerializedName("PageSize") val pageSize: Int?
 ) {
     val pageCount: Int
-        get() = if (pageSize != null && pageSize > 0) (allArtistsCount / pageSize) + 1 else 1
+        get() = if (pageSize != null && pageSize > 0) (allArtistsCount + pageSize - 1) / pageSize else 1
 }

--- a/android/app/src/test/java/com/wikiart/ArtistsListTest.kt
+++ b/android/app/src/test/java/com/wikiart/ArtistsListTest.kt
@@ -1,0 +1,35 @@
+import com.wikiart.model.ArtistsList
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtistsListTest {
+    @Test
+    fun pageCountNullPageSize() {
+        val list = ArtistsList(emptyList(), allArtistsCount = 10, pageSize = null)
+        assertEquals(1, list.pageCount)
+    }
+
+    @Test
+    fun pageCountZeroPageSize() {
+        val list = ArtistsList(emptyList(), allArtistsCount = 10, pageSize = 0)
+        assertEquals(1, list.pageCount)
+    }
+
+    @Test
+    fun pageCountZeroArtists() {
+        val list = ArtistsList(emptyList(), allArtistsCount = 0, pageSize = 5)
+        assertEquals(0, list.pageCount)
+    }
+
+    @Test
+    fun pageCountExactMultiple() {
+        val list = ArtistsList(emptyList(), allArtistsCount = 10, pageSize = 5)
+        assertEquals(2, list.pageCount)
+    }
+
+    @Test
+    fun pageCountRoundsUp() {
+        val list = ArtistsList(emptyList(), allArtistsCount = 9, pageSize = 5)
+        assertEquals(2, list.pageCount)
+    }
+}


### PR DESCRIPTION
## Summary
- round up `ArtistsList` pageCount correctly
- test edge cases for ArtistsList pageCount

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684933f3127c832e94be17e555c35e7a