### PR TITLE
Move secrets to gradle properties

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /app/build/
 .idea/
+local.properties

--- a/android/README.md
+++ b/android/README.md
@@ -16,3 +16,26 @@ To build the project, open the `android` directory in Android Studio or run
 plugin are installed). To test the billing flow you must sign in with a Google
 Play test account on your device and upload the in-app products in the Play
 Console.
+
+## Secrets
+
+Create a `local.properties` file in the `android` directory or define the
+following environment variables before building:
+
+```
+IS_OSS=false
+FIELD_REPORT_EMAIL=<your email>
+API_CLIENT_PRODUCTION=<client id>
+API_CLIENT_STAGING=<staging client id>
+API_ENDPOINT_PRODUCTION=<production endpoint>
+API_ENDPOINT_STAGING=<staging endpoint>
+BASIC_HTTP_AUTH_USERNAME=<username>
+BASIC_HTTP_AUTH_PASSWORD=<password>
+CANVAS_POP_ACCESS_KEY=<canvaspop access>
+CANVAS_POP_SECRET_KEY=<canvaspop secret>
+KITE_SECRET=<kite secret>
+KITE_PUBLIC_KEY=<kite public key>
+```
+
+Values from `local.properties` take precedence, falling back to the environment
+when not present.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,15 +4,48 @@ plugins {
     id 'kotlin-kapt'
 }
 
+def localProps = new Properties()
+def localPropsFile = rootProject.file("local.properties")
+if (localPropsFile.exists()) {
+    localProps.load(new FileInputStream(localPropsFile))
+}
+def getSecret = { name ->
+    return localProps.getProperty(name) ?: System.getenv(name)
+}
+
+def stringField = { name ->
+    return '"' + (getSecret(name) ?: '') + '"'
+}
+
+def booleanField = { name, defaultVal ->
+    def v = getSecret(name)
+    return v != null ? v : defaultVal
+}
+
 android {
     compileSdkVersion 33
     namespace "com.wikiart"
+    buildFeatures {
+        buildConfig true
+    }
     defaultConfig {
         applicationId "com.wikiart"
         minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"
+        buildConfigField "boolean", "IS_OSS", booleanField("IS_OSS", "false")
+        buildConfigField "String", "FIELD_REPORT_EMAIL", stringField("FIELD_REPORT_EMAIL")
+        buildConfigField "String", "API_CLIENT_PRODUCTION", stringField("API_CLIENT_PRODUCTION")
+        buildConfigField "String", "API_CLIENT_STAGING", stringField("API_CLIENT_STAGING")
+        buildConfigField "String", "API_ENDPOINT_PRODUCTION", stringField("API_ENDPOINT_PRODUCTION")
+        buildConfigField "String", "API_ENDPOINT_STAGING", stringField("API_ENDPOINT_STAGING")
+        buildConfigField "String", "BASIC_HTTP_AUTH_USERNAME", stringField("BASIC_HTTP_AUTH_USERNAME")
+        buildConfigField "String", "BASIC_HTTP_AUTH_PASSWORD", stringField("BASIC_HTTP_AUTH_PASSWORD")
+        buildConfigField "String", "CANVAS_POP_ACCESS_KEY", stringField("CANVAS_POP_ACCESS_KEY")
+        buildConfigField "String", "CANVAS_POP_SECRET_KEY", stringField("CANVAS_POP_SECRET_KEY")
+        buildConfigField "String", "KITE_SECRET", stringField("KITE_SECRET")
+        buildConfigField "String", "KITE_PUBLIC_KEY", stringField("KITE_PUBLIC_KEY")
     }
     buildTypes {
         release {

--- a/android/app/src/main/java/com/wikiart/Secrets.kt
+++ b/android/app/src/main/java/com/wikiart/Secrets.kt
@@ -1,33 +1,33 @@
 package com.wikiart
 
 object Secrets {
-    const val IS_OSS = false
-    const val FIELD_REPORT_EMAIL = "hello@email.com"
+    val IS_OSS = BuildConfig.IS_OSS
+    val FIELD_REPORT_EMAIL = BuildConfig.FIELD_REPORT_EMAIL
 
     object Api {
         object Client {
-            const val PRODUCTION = "deadbeef"
-            const val STAGING = "beefdead"
+            val PRODUCTION = BuildConfig.API_CLIENT_PRODUCTION
+            val STAGING = BuildConfig.API_CLIENT_STAGING
         }
 
         object Endpoint {
-            const val PRODUCTION = "www.wikiart.org"
-            const val STAGING = "www.wikiart.org"
+            val PRODUCTION = BuildConfig.API_ENDPOINT_PRODUCTION
+            val STAGING = BuildConfig.API_ENDPOINT_STAGING
         }
     }
 
     object BasicHTTPAuth {
-        const val USERNAME = "usr"
-        const val PASSWORD = "pswd"
+        val USERNAME = BuildConfig.BASIC_HTTP_AUTH_USERNAME
+        val PASSWORD = BuildConfig.BASIC_HTTP_AUTH_PASSWORD
     }
 
     object CanvasPopKeys {
-        const val ACCESS_KEY = ""
-        const val SECRET_KEY = ""
+        val ACCESS_KEY = BuildConfig.CANVAS_POP_ACCESS_KEY
+        val SECRET_KEY = BuildConfig.CANVAS_POP_SECRET_KEY
     }
 
     object KiteKeys {
-        const val SECRET = ""
-        const val PUBLIC_KEY = ""
+        val SECRET = BuildConfig.KITE_SECRET
+        val PUBLIC_KEY = BuildConfig.KITE_PUBLIC_KEY
     }
 }


### PR DESCRIPTION
## Summary
- read keys from `local.properties` or env vars
- expose them to Kotlin via BuildConfig
- ignore `local.properties`
- document required keys in the Android README

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493403285c832eae7e00ba9c9a30f3