### PR TITLE
Localize section titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ using Coil, and tapping an item opens a detail screen. You can search with
 autocomplete suggestions, mark paintings as favourites, view artist details and
 share or buy prints of a painting. Images can also be viewed full screen with
 pinch‑to‑zoom and a Support screen lets you send feedback or donate via
-Google Play in‑app purchases.
+Google Play in‑app purchases. Section titles are localized using your device
+language with a fallback to English when needed.

--- a/android/README.md
+++ b/android/README.md
@@ -10,6 +10,8 @@ Additional screens let you search with autocomplete, manage favourites and view
 artist information. You can share or buy prints of a painting, view the image in
 full screen and visit a Support screen to send feedback or make a donation
 using Google Play Billing.
+Section titles in category dialogs are shown in your device language when
+available, defaulting to English otherwise.
 
 To build the project, open the `android` directory in Android Studio or run
 `gradle assembleDebug` from this folder (ensure the Android SDK and Kotlin

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -11,6 +11,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import androidx.appcompat.app.AlertDialog
+import java.util.Locale
 
 import androidx.appcompat.app.AppCompatActivity
 import android.view.Menu
@@ -39,6 +40,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        val deviceLanguage = Locale.getDefault().language
+
         val recyclerView: RecyclerView = findViewById(R.id.paintingRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = adapter
@@ -55,7 +58,7 @@ class MainActivity : AppCompatActivity() {
                     lifecycleScope.launch {
                         val sections = repository.sections(category)
                         if (sections.isNotEmpty()) {
-                            showSectionDialog(category, sections)
+                            showSectionDialog(category, sections, deviceLanguage)
                         }
                     }
                 } else {
@@ -82,8 +85,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun showSectionDialog(category: PaintingCategory, sections: List<PaintingSection>) {
-        val names = sections.map { it.titleForLanguage("en") }.toTypedArray()
+    private fun showSectionDialog(category: PaintingCategory, sections: List<PaintingSection>, language: String) {
+        val names = sections.map { it.titleForLanguage(language) }.toTypedArray()
         val categoryNames = resources.getStringArray(R.array.painting_category_names)
         val title = categoryNames[categories.indexOf(category)]
         AlertDialog.Builder(this)

--- a/android/app/src/test/java/com/wikiart/PaintingSectionTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingSectionTest.kt
@@ -1,0 +1,17 @@
+import com.wikiart.model.PaintingSection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PaintingSectionTest {
+    @Test
+    fun titleForLanguageFallbacksToEnglish() {
+        val map = mapOf("en" to "English Title", "fr" to "Titre Francais")
+        val section = PaintingSection(
+            PaintingSection.Id("1"),
+            PaintingSection.Content(
+                PaintingSection.Content.Title(map)
+            )
+        )
+        assertEquals("English Title", section.titleForLanguage("de"))
+    }
+}


### PR DESCRIPTION
## Summary
- show localized section titles using device language
- document fallback to English
- test `PaintingSection.titleForLanguage`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684936fd1540832ebfab587faaaf877c