### PR TITLE
Use secret email for feedback

### DIFF
--- a/android/app/src/main/java/com/wikiart/SupportActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SupportActivity.kt
@@ -40,10 +40,15 @@ class SupportActivity : AppCompatActivity(), PurchasesUpdatedListener {
         })
 
         findViewById<Button>(R.id.feedbackButton).setOnClickListener {
-            val intent = Intent(Intent.ACTION_SENDTO).apply {
-                data = Uri.parse("mailto:wikiartfeedback@icloud.com")
+            val email = Secrets.FIELD_REPORT_EMAIL
+            if (email.isBlank()) {
+                Toast.makeText(this, R.string.feedback_unavailable, Toast.LENGTH_SHORT).show()
+            } else {
+                val intent = Intent(Intent.ACTION_SENDTO).apply {
+                    data = Uri.parse("mailto:$email")
+                }
+                startActivity(intent)
             }
-            startActivity(intent)
         }
 
         findViewById<Button>(R.id.donateButton).setOnClickListener {

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -13,6 +13,7 @@
     <string name="famous_works">Obras famosas</string>
     <string name="support">Soporte</string>
     <string name="send_feedback">Enviar comentarios</string>
+    <string name="feedback_unavailable">Correo de comentarios no disponible</string>
     <string name="donate">Donar</string>
     <string name="thank_you">¡Gracias por tu apoyo!</string>
     <string name="artists">Artistas</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -13,6 +13,7 @@
     <string name="famous_works">Известные работы</string>
     <string name="support">Поддержка</string>
     <string name="send_feedback">Отправить отзыв</string>
+    <string name="feedback_unavailable">Адрес для отзывов недоступен</string>
     <string name="donate">Пожертвовать</string>
     <string name="thank_you">Спасибо за вашу поддержку!</string>
     <string name="artists">Художники</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
     <string name="support">Support</string>
     <string name="send_feedback">Send Feedback</string>
+    <string name="feedback_unavailable">Feedback email unavailable</string>
     <string name="donate">Donate</string>
     <string name="thank_you">Thank you for your support!</string>
     <string name="artists">Artists</string>


### PR DESCRIPTION
## Summary
- reference `Secrets.FIELD_REPORT_EMAIL` for the feedback address
- show a toast when the secret email is missing
- add translations for the new "feedback_unavailable" string

## Testing
- `gradle -p android assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493709f554832e92056a21743ca6a2