### PR TITLE
Add Firebase Analytics on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'com.google.gms.google-services'
 }
 
 def localProps = new Properties()
@@ -71,5 +72,7 @@ dependencies {
     kapt "androidx.room:room-compiler:2.6.1"
     implementation "androidx.room:room-ktx:2.6.1"
     implementation 'com.android.billingclient:billing-ktx:6.1.0'
+    implementation platform('com.google.firebase:firebase-bom:33.15.0')
+    implementation 'com.google.firebase:firebase-analytics-ktx'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.wikiart.model.PaintingSection
 import com.wikiart.SupportActivity
+import com.google.firebase.FirebaseApp
+import com.google.firebase.analytics.FirebaseAnalytics
 
 class MainActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
@@ -34,9 +36,13 @@ class MainActivity : AppCompatActivity() {
     private val repository = PaintingRepository()
     private var pagingJob: Job? = null
     private var currentSectionId: String? = null
+    private lateinit var firebaseAnalytics: FirebaseAnalytics
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        FirebaseApp.initializeApp(this)
+        firebaseAnalytics = FirebaseAnalytics.getInstance(this)
+        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.APP_OPEN, null)
         setContentView(R.layout.activity_main)
 
         val recyclerView: RecyclerView = findViewById(R.id.paintingRecyclerView)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
+        // Add Google services Gradle plugin for Firebase
+        classpath 'com.google.gms:google-services:4.4.2'
     }
 }
 


### PR DESCRIPTION
## Summary
- include Google services plugin in Android build
- depend on Firebase Analytics
- initialize FirebaseApp and log app open event

## Testing
- `gradle -p android build` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684937169bb8832e8e03ebb2598120b5