### PR TITLE
Add material icons for bottom navigation

### DIFF
--- a/android/app/src/main/res/drawable/ic_artists.xml
+++ b/android/app/src/main/res/drawable/ic_artists.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_gallery.xml
+++ b/android/app/src/main/res/drawable/ic_gallery.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M22 16V4c0-1.1-.9-2-2-2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2zm-11-4l2.03 2.71L16 11l4 5H8l3-4zM2 6v14c0 1.1.9 2 2 2h14v-2H4V6H2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_search.xml
+++ b/android/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_support.xml
+++ b/android/app/src/main/res/drawable/ic_support.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
+</vector>

--- a/android/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/android/app/src/main/res/menu/bottom_nav_menu.xml
@@ -3,17 +3,17 @@
     <item
         android:id="@+id/nav_paintings"
         android:title="@string/painting_category_popular"
-        android:icon="@android:drawable/ic_menu_gallery" />
+        android:icon="@drawable/ic_gallery" />
     <item
         android:id="@+id/nav_artists"
         android:title="@string/artists"
-        android:icon="@android:drawable/ic_menu_manage" />
+        android:icon="@drawable/ic_artists" />
     <item
         android:id="@+id/nav_search"
         android:title="@string/search"
-        android:icon="@android:drawable/ic_menu_search" />
+        android:icon="@drawable/ic_search" />
     <item
         android:id="@+id/nav_support"
         android:title="@string/support"
-        android:icon="@android:drawable/ic_menu_help" />
+        android:icon="@drawable/ic_support" />
 </menu>


### PR DESCRIPTION
## Summary
- add vector drawables for Gallery, Artists, Search, and Support
- update `bottom_nav_menu.xml` to reference the new drawables

## Testing
- `gradle tasks -q`
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493a8acc5c832e937e7bd38af5d3a7