### PR TITLE
Remove unused MainActivity UI setup

### DIFF
--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -4,32 +4,10 @@ import android.os.Bundle
 
 import android.content.Intent
 
-import android.view.Menu
-import android.view.MenuItem
-
-import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
-import android.widget.Spinner
-import androidx.appcompat.app.AlertDialog
-import java.util.Locale
-
-
 import androidx.appcompat.app.AppCompatActivity
-
-import android.view.Menu
-import android.view.MenuItem
-import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.paging.cachedIn
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import com.wikiart.model.PaintingSection
 import com.wikiart.SupportActivity
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
-
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
@@ -39,15 +17,7 @@ class MainActivity : AppCompatActivity() {
     companion object {
         private const val SUPPORT_TRIGGER_VALUE = 3
     }
-    private val adapter = PaintingAdapter { painting ->
-        val intent = Intent(this, PaintingDetailActivity::class.java)
-        intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        startActivity(intent)
-    }
 
-    private val repository = PaintingRepository()
-    private var pagingJob: Job? = null
-    private var currentSectionId: String? = null
     private lateinit var firebaseAnalytics: FirebaseAnalytics
 
 
@@ -71,36 +41,6 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragmentContainer, PaintingsFragment())
                 .commit()
-}
-        val deviceLanguage = Locale.getDefault().language
-
-        val recyclerView: RecyclerView = findViewById(R.id.paintingRecyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(this)
-        recyclerView.adapter = adapter
-
-        val spinner: Spinner = findViewById(R.id.categorySpinner)
-        val categories = PaintingCategory.values()
-        val categoryNames = resources.getStringArray(R.array.painting_category_names)
-        spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, categoryNames)
-
-        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                val category = categories[position]
-                if (category.hasSections()) {
-                    lifecycleScope.launch {
-                        val sections = repository.sections(category)
-                        if (sections.isNotEmpty()) {
-                            showSectionDialog(category, sections, deviceLanguage)
-                        }
-                    }
-                } else {
-                    currentSectionId = null
-                    loadCategory(category)
-                }
-            }
-
-            override fun onNothingSelected(parent: AdapterView<*>) {}
-
         }
 
         val nav: BottomNavigationView = findViewById(R.id.bottomNavigation)
@@ -125,20 +65,6 @@ class MainActivity : AppCompatActivity() {
                 }
                 else -> false
 
-        }
-    }
-
-    private fun showSectionDialog(category: PaintingCategory, sections: List<PaintingSection>, language: String) {
-        val names = sections.map { it.titleForLanguage(language) }.toTypedArray()
-        val categoryNames = resources.getStringArray(R.array.painting_category_names)
-        val title = categoryNames[categories.indexOf(category)]
-        AlertDialog.Builder(this)
-            .setTitle(title)
-            .setItems(names) { _, which ->
-                currentSectionId = sections[which].id.oid
-                loadCategory(category, currentSectionId)
-
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- clean up imports in `MainActivity`
- drop old RecyclerView/Spinner initialization
- keep only fragment switching via `BottomNavigationView`

## Testing
- `./gradlew test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68493a852940832eb110120f401461a9