### PR TITLE
Add PagingSource tests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,4 +76,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.15.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'io.mockk:mockk:1.14.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+    testImplementation 'androidx.paging:paging-common:3.2.1'
 }

--- a/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
@@ -1,0 +1,34 @@
+import androidx.paging.Pager
+import com.wikiart.PaintingRepository
+import com.wikiart.PaintingCategory
+import com.wikiart.WikiArtPagingSource
+import com.wikiart.WikiArtService
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaintingRepositoryTest {
+    @Test
+    fun pagingFlowCreatesWikiArtPagingSource() {
+        val service = mockk<WikiArtService>(relaxed = true)
+        val repo = PaintingRepository(service)
+        val flow = repo.pagingFlow(PaintingCategory.FEATURED, "section")
+
+        val field = flow.javaClass.getDeclaredField("this$0")
+        field.isAccessible = true
+        val pager = field.get(flow) as Pager<*, *>
+        val source = pager.pagingSourceFactory.invoke()
+        assertTrue(source is WikiArtPagingSource)
+
+        val serviceField = WikiArtPagingSource::class.java.getDeclaredField("service")
+        val categoryField = WikiArtPagingSource::class.java.getDeclaredField("category")
+        val sectionField = WikiArtPagingSource::class.java.getDeclaredField("sectionId")
+        serviceField.isAccessible = true
+        categoryField.isAccessible = true
+        sectionField.isAccessible = true
+        assertEquals(service, serviceField.get(source))
+        assertEquals(PaintingCategory.FEATURED, categoryField.get(source))
+        assertEquals("section", sectionField.get(source))
+    }
+}

--- a/android/app/src/test/java/com/wikiart/WikiArtPagingSourceTest.kt
+++ b/android/app/src/test/java/com/wikiart/WikiArtPagingSourceTest.kt
@@ -1,0 +1,40 @@
+import androidx.paging.PagingSource
+import com.wikiart.WikiArtPagingSource
+import com.wikiart.WikiArtService
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WikiArtPagingSourceTest {
+    @Test
+    fun loadHandlesEmptyResponse() = runBlocking {
+        val service = mockk<WikiArtService>()
+        coEvery { service.fetchPaintings(PaintingCategory.FEATURED, 1, null) } returns
+            PaintingList(emptyList(), 0, 20)
+
+        val source = WikiArtPagingSource(service, PaintingCategory.FEATURED)
+        val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
+        val result = source.load(params)
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        result as PagingSource.LoadResult.Page
+        assertTrue(result.data.isEmpty())
+        assertEquals(null, result.prevKey)
+        assertEquals(null, result.nextKey)
+    }
+
+    @Test
+    fun loadReturnsError() = runBlocking {
+        val service = mockk<WikiArtService>()
+        coEvery { service.fetchPaintings(PaintingCategory.FEATURED, 1, null) } throws RuntimeException("boom")
+
+        val source = WikiArtPagingSource(service, PaintingCategory.FEATURED)
+        val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
+        val result = source.load(params)
+
+        assertTrue(result is PagingSource.LoadResult.Error)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `PaintingRepository.pagingFlow`
- test `WikiArtPagingSource` error/empty cases
- include mockk and test libs

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493a9091f0832e856804d0e082fad8