### PR TITLE
Enable shared element transition for painting images

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import android.widget.Button
 import android.widget.Toast
 import android.view.View
+import android.app.ActivityOptions
 import com.wikiart.ImageDetailActivity
 import coil.load
 import androidx.lifecycle.lifecycleScope
@@ -35,7 +36,12 @@ class PaintingDetailActivity : AppCompatActivity() {
         detailImage.setOnClickListener {
             val intent = Intent(this, ImageDetailActivity::class.java)
             intent.putExtra(ImageDetailActivity.EXTRA_IMAGE_URL, imageUrl)
-            startActivity(intent)
+            val options = ActivityOptions.makeSceneTransitionAnimation(
+                this,
+                detailImage,
+                "detailImage"
+            )
+            startActivity(intent, options.toBundle())
         }
 
 

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -7,5 +7,6 @@
         android:id="@+id/fullImageView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scaleType="fitCenter"/>
+        android:scaleType="fitCenter"
+        android:transitionName="detailImage"/>
 </FrameLayout>

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -13,6 +13,7 @@
             android:id="@+id/detailImage"
             android:layout_width="match_parent"
             android:layout_height="300dp"
+            android:transitionName="detailImage"
             android:scaleType="centerCrop" />
 
         <TextView


### PR DESCRIPTION
## Summary
- add a transition name to the painting image
- animate to ImageDetailActivity using ActivityOptions
- use the same transition name in the image detail layout

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849404bf538832ea1cc9a3923823bc7