### PR TITLE
Add Material transitions

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -2,6 +2,7 @@ package com.wikiart
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import android.app.ActivityOptions
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -15,7 +16,9 @@ class ArtistDetailActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
         val intent = android.content.Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        startActivity(intent, options.toBundle())
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.content.Intent
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
@@ -22,7 +23,9 @@ class ArtistsActivity : AppCompatActivity() {
         val intent = Intent(this, ArtistDetailActivity::class.java)
         intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, artist.artistUrl)
         intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artist.title)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        startActivity(intent, options.toBundle())
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.content.Intent
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -23,7 +24,9 @@ class ArtistsFragment : Fragment() {
         val intent = Intent(requireContext(), ArtistDetailActivity::class.java)
         intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, artist.artistUrl)
         intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artist.title)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        startActivity(intent, options.toBundle())
+        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.content.Intent
+import android.app.ActivityOptions
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -15,7 +16,9 @@ class FavoritesActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        startActivity(intent, options.toBundle())
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -3,6 +3,8 @@ package com.wikiart
 import android.os.Bundle
 
 import android.content.Intent
+import android.app.ActivityOptions
+import com.google.android.material.transition.platform.MaterialFadeThrough
 
 import androidx.appcompat.app.AppCompatActivity
 import com.wikiart.SupportActivity
@@ -33,7 +35,10 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             val random = (1..5).random()
             if (random == SUPPORT_TRIGGER_VALUE) {
-                startActivity(Intent(this, SupportActivity::class.java))
+                val intent = Intent(this, SupportActivity::class.java)
+                val options = ActivityOptions.makeSceneTransitionAnimation(this)
+                startActivity(intent, options.toBundle())
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
             }
         }
 
@@ -61,7 +66,10 @@ class MainActivity : AppCompatActivity() {
                     true
                 }
                 R.id.nav_favorites -> {
-                    startActivity(Intent(this, FavoritesActivity::class.java))
+                    val intent = Intent(this, FavoritesActivity::class.java)
+                    val options = ActivityOptions.makeSceneTransitionAnimation(this)
+                    startActivity(intent, options.toBundle())
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
                     true
                 }
                 R.id.nav_support -> {
@@ -74,6 +82,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun switchFragment(fragment: Fragment) {
+        fragment.enterTransition = MaterialFadeThrough()
+        fragment.exitTransition = MaterialFadeThrough()
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragmentContainer, fragment)
             .commit()

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -71,7 +71,9 @@ class PaintingDetailActivity : AppCompatActivity() {
             val intent = Intent(this, ArtistDetailActivity::class.java)
             intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, url)
             intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artistName)
-            startActivity(intent)
+            val options = ActivityOptions.makeSceneTransitionAnimation(this)
+            startActivity(intent, options.toBundle())
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
 
         }
 
@@ -115,7 +117,9 @@ class PaintingDetailActivity : AppCompatActivity() {
             painting ?: return@setOnClickListener
             val intent = Intent(this, StoreActivity::class.java)
             intent.putExtra(StoreActivity.EXTRA_IMAGE_URL, painting.image)
-            startActivity(intent)
+            val options = ActivityOptions.makeSceneTransitionAnimation(this)
+            startActivity(intent, options.toBundle())
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         }
 
         val relatedRecycler: RecyclerView = findViewById(R.id.relatedRecyclerView)
@@ -123,7 +127,9 @@ class PaintingDetailActivity : AppCompatActivity() {
         val relatedAdapter = RelatedPaintingAdapter { selected ->
             val intent = Intent(this, PaintingDetailActivity::class.java)
             intent.putExtra(EXTRA_PAINTING, selected)
-            startActivity(intent)
+            val options = ActivityOptions.makeSceneTransitionAnimation(this)
+            startActivity(intent, options.toBundle())
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         }
         relatedRecycler.layoutManager = LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
         relatedRecycler.adapter = relatedAdapter

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.content.Intent
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,7 +21,9 @@ class PaintingsFragment : Fragment() {
     private val adapter = PaintingAdapter { painting ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        startActivity(intent, options.toBundle())
+        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -2,6 +2,7 @@ package com.wikiart
 
 import android.os.Bundle
 import android.content.Intent
+import android.app.ActivityOptions
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -21,7 +22,9 @@ class SearchActivity : AppCompatActivity() {
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
         intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        startActivity(intent, options.toBundle())
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -1,6 +1,7 @@
 package com.wikiart
 
 import android.content.Intent
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -24,7 +25,9 @@ class SearchFragment : Fragment() {
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
         intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
-        startActivity(intent)
+        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        startActivity(intent, options.toBundle())
+        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository = PaintingRepository()

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:transitionName="paintingDetail">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_paintings.xml
+++ b/android/app/src/main/res/layout/fragment_paintings.xml
@@ -13,5 +13,6 @@
         android:id="@+id/paintingRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:transitionName="paintingList" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- use `MaterialFadeThrough` when swapping fragments
- launch activities with scene transition animations and fade
- add transition names for detail and list layouts

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6849425e2b44832ea0037b3743d46663