### PR TITLE
Update AppVersion to return optional

### DIFF
--- a/WikiArt3.0/System/AppLauncherTemplate.swift
+++ b/WikiArt3.0/System/AppLauncherTemplate.swift
@@ -50,7 +50,7 @@ open class AppLauncherTemplate {
     }
     
     func updateLastLaunchVersion() {
-        Current.userDefaults.lastLaunchAppVersion = AppVersion.bundleVersion
+        Current.userDefaults.lastLaunchAppVersion = AppVersion.current?.rawValue
     }
     
     func requestSupport() {

--- a/WikiArt3.0/System/AppVersion.swift
+++ b/WikiArt3.0/System/AppVersion.swift
@@ -40,8 +40,11 @@ extension AppVersion {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }
     
-    static var current: AppVersion {
-        return AppVersion(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)!
+    static var current: AppVersion? {
+        guard let versionString = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+            return nil
+        }
+        return AppVersion(versionString)
     }
     
     static var lastLaunchVersion: AppVersion? {


### PR DESCRIPTION
## Summary
- avoid force-unwrapping when reading the bundle version
- store the optional `AppVersion` during launch

## Testing
- `gradle -p android test --no-daemon -i` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849463d1d54832e99c8f8f80f7d5a5d