### PR TITLE
Add layout switching feature

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -6,6 +6,7 @@ Scrolling now loads additional pages automatically using the
 Paging library. Each item displays the painting image using Coil and tapping a
 painting opens a detail screen showing a larger image and the title. A spinner
 at the top allows choosing a painting category and the list updates accordingly.
+A menu in Paintings lets you switch between list, grid and sheet layouts; your choice is saved.
 Additional screens let you search with autocomplete, manage favourites and view
 artist information. You can share or buy prints of a painting, view the image in
 full screen and visit a Support screen to send feedback or make a donation using

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -9,14 +9,23 @@ import coil.load
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.PagingDataAdapter
+import com.wikiart.model.LayoutType
 
 class PaintingAdapter(
+    var layoutType: LayoutType = LayoutType.LIST,
     private val onItemClick: (Painting) -> Unit = {}
 ) : PagingDataAdapter<Painting, PaintingAdapter.PaintingViewHolder>(DIFF_CALLBACK) {
 
+    override fun getItemViewType(position: Int): Int = layoutType.ordinal
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
+        val layout = when (layoutType) {
+            LayoutType.SHEET -> R.layout.item_painting_sheet
+            LayoutType.COLUMN -> R.layout.item_painting_grid
+            else -> R.layout.list_item_painting
+        }
         val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.list_item_painting, parent, false)
+            .inflate(layout, parent, false)
         return PaintingViewHolder(view)
     }
 

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -11,13 +11,24 @@ import android.widget.Spinner
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
+import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.content.Context
+import com.wikiart.model.LayoutType
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class PaintingsFragment : Fragment() {
-    private val adapter = PaintingAdapter { painting ->
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: PaintingAdapter
+    private var layoutType: LayoutType = LayoutType.LIST
+
+    private val itemClick: (Painting) -> Unit = { painting ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
         startActivity(intent)
@@ -32,13 +43,19 @@ class PaintingsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_paintings, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val recyclerView: RecyclerView = view.findViewById(R.id.paintingRecyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        val prefs = requireContext().getSharedPreferences("prefs", Context.MODE_PRIVATE)
+        val name = prefs.getString("layout_type", LayoutType.LIST.name) ?: LayoutType.LIST.name
+        layoutType = runCatching { LayoutType.valueOf(name) }.getOrDefault(LayoutType.LIST)
+
+        recyclerView = view.findViewById(R.id.paintingRecyclerView)
+        adapter = PaintingAdapter(layoutType, itemClick)
+        recyclerView.layoutManager = layoutManagerFor(layoutType)
         recyclerView.adapter = adapter
 
         val spinner: Spinner = view.findViewById(R.id.categorySpinner)
@@ -66,6 +83,32 @@ class PaintingsFragment : Fragment() {
         }
 
         loadCategory(PaintingCategory.FEATURED)
+    }
+
+    private fun layoutManagerFor(type: LayoutType): RecyclerView.LayoutManager = when (type) {
+        LayoutType.COLUMN -> GridLayoutManager(requireContext(), 2)
+        LayoutType.SHEET -> StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
+        else -> LinearLayoutManager(requireContext())
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.layout_menu, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        val prefs = requireContext().getSharedPreferences("prefs", Context.MODE_PRIVATE)
+        layoutType = when (item.itemId) {
+            R.id.layout_list -> LayoutType.LIST
+            R.id.layout_grid -> LayoutType.COLUMN
+            R.id.layout_sheet -> LayoutType.SHEET
+            else -> return super.onOptionsItemSelected(item)
+        }
+        prefs.edit().putString("layout_type", layoutType.name).apply()
+        adapter.layoutType = layoutType
+        adapter.notifyDataSetChanged()
+        recyclerView.layoutManager = layoutManagerFor(layoutType)
+        return true
     }
 
     private fun loadCategory(category: PaintingCategory, sectionId: String? = null) {

--- a/android/app/src/main/java/com/wikiart/model/LayoutType.kt
+++ b/android/app/src/main/java/com/wikiart/model/LayoutType.kt
@@ -1,0 +1,12 @@
+package com.wikiart.model
+
+/**
+ * Mirror of Layout enum from iOS codebase.
+ */
+enum class LayoutType {
+    LIST,
+    SHEET,
+    COLUMN,
+    ARTIST,
+    PAINTING_ROW
+}

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="4dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_painting_sheet.xml
+++ b/android/app/src/main/res/layout/item_painting_sheet.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="2dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+</LinearLayout>

--- a/android/app/src/main/res/menu/layout_menu.xml
+++ b/android/app/src/main/res/menu/layout_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/layout_list"
+        android:title="List" />
+    <item
+        android:id="@+id/layout_grid"
+        android:title="Grid" />
+    <item
+        android:id="@+id/layout_sheet"
+        android:title="Sheet" />
+</menu>


### PR DESCRIPTION
## Summary
- add new `LayoutType` enum to match iOS layouts
- support grid and sheet item layouts
- update `PaintingAdapter` to use layout type
- allow choosing layout in `PaintingsFragment` with persistence
- document layout selection in README

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493e52fbc0832e80f5bc03750112d7