### PR TITLE
Specify JVM target

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,13 @@ def booleanField = { name, defaultVal ->
 android {
     compileSdkVersion 33
     namespace "com.wikiart"
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
     buildFeatures {
         buildConfig true
     }


### PR DESCRIPTION
## Summary
- set compile options for Java 17
- specify Kotlin `jvmTarget` 17 to avoid JDK 21 incompatibility

## Testing
- `gradle -p android help`
- `gradle -p android assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495c0c72ac832eae04e1a03feb7cb5