### PR TITLE
Fix AndroidX build error

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier

## Testing
- `gradle assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495fc577fc832e9f5525e89a709047