### PR TITLE
Update min SDK to 24

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     defaultConfig {
         applicationId "com.wikiart"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## Summary
- bump Android `minSdkVersion` from 21 to 24

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest')*

------
https://chatgpt.com/codex/tasks/task_e_684b30ba7890832e8fb489cd1d92d025