### PR TITLE
Update Android buildscript repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
@@ -13,5 +14,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
## Summary
- add `jitpack.io` repository to buildscript and allprojects sections in `android/build.gradle`

## Testing
- `gradle -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3263b844832ebd643841e41d7c0f