### PR TITLE
Specify exported flag

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- Add `android:exported="true"` to `MainActivity` so Gradle can merge the manifest targeting Android 12+

## Testing
- `gradle build` *(fails: Gradle not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b388e7d58832ebe2372e131108140