### PR TITLE
Handle default WikiArt endpoint

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -43,4 +43,5 @@ KITE_PUBLIC_KEY=<kite public key>
 ```
 
 Values from `local.properties` take precedence, falling back to the environment
-when not present.
+when not present. If the API endpoint values are blank the app defaults to
+`www.wikiart.org`.

--- a/android/app/src/main/java/com/wikiart/ServerConfig.kt
+++ b/android/app/src/main/java/com/wikiart/ServerConfig.kt
@@ -14,8 +14,19 @@ data class ServerConfig(
     override val environment: EnvironmentType = EnvironmentType.PRODUCTION
 ) : ServerConfigType {
     companion object {
-        val production: ServerConfigType = ServerConfig(URL("https://${Secrets.Api.Endpoint.PRODUCTION}"), EnvironmentType.PRODUCTION)
-        val staging: ServerConfigType = ServerConfig(URL("https://${Secrets.Api.Endpoint.STAGING}"), EnvironmentType.STAGING)
+        private const val DEFAULT_API_ENDPOINT = "www.wikiart.org"
+
+        val production: ServerConfigType =
+            ServerConfig(
+                URL("https://${Secrets.Api.Endpoint.PRODUCTION.ifBlank { DEFAULT_API_ENDPOINT }}"),
+                EnvironmentType.PRODUCTION
+            )
+
+        val staging: ServerConfigType =
+            ServerConfig(
+                URL("https://${Secrets.Api.Endpoint.STAGING.ifBlank { DEFAULT_API_ENDPOINT }}"),
+                EnvironmentType.STAGING
+            )
 
         fun config(environment: EnvironmentType) = when(environment) {
             EnvironmentType.PRODUCTION -> production


### PR DESCRIPTION
## Summary
- default to `www.wikiart.org` when API endpoints are empty
- document default endpoint fallback

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b480995e8832ea30f3cf85e11c5a0