### PR TITLE
Implement FavoritesFragment

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
         </activity>
         <activity android:name=".PaintingDetailActivity" />
         <activity android:name=".SearchActivity" />
-        <activity android:name=".FavoritesActivity" />
-
         <activity android:name=".StoreActivity" />
         <activity
             android:name=".ImageDetailActivity"

--- a/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
@@ -1,0 +1,43 @@
+package com.wikiart
+
+import android.content.Intent
+import android.app.ActivityOptions
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.wikiart.data.FavoritesRepository
+import kotlinx.coroutines.launch
+
+class FavoritesFragment : Fragment() {
+    private val adapter = PaintingAdapter { painting ->
+        val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
+        intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        startActivity(intent, options.toBundle())
+        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.fragment_favorites, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val recyclerView: RecyclerView = view.findViewById(R.id.favoritesRecyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+
+        val repository = FavoritesRepository(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            repository.favoritesFlow().collect { list ->
+                adapter.submitData(lifecycle, PagingData.from(list))
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -8,7 +8,7 @@ import com.google.android.material.transition.platform.MaterialFadeThrough
 
 import androidx.appcompat.app.AppCompatActivity
 import com.wikiart.SupportActivity
-import com.wikiart.FavoritesActivity
+import com.wikiart.FavoritesFragment
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
@@ -60,10 +60,7 @@ class MainActivity : AppCompatActivity() {
                     true
                 }
                 R.id.nav_favorites -> {
-                    val intent = Intent(this, FavoritesActivity::class.java)
-                    val options = ActivityOptions.makeSceneTransitionAnimation(this)
-                    startActivity(intent, options.toBundle())
-                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+                    switchFragment(FavoritesFragment())
                     true
                 }
                 R.id.nav_support -> {

--- a/android/app/src/main/res/layout/fragment_favorites.xml
+++ b/android/app/src/main/res/layout/fragment_favorites.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/favoritesRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add FavoritesFragment for tabbed navigation
- create fragment_favorites.xml layout
- switch favorites tab to fragment based navigation
- remove obsolete FavoritesActivity from manifest

## Testing
- `sh ./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4b76279c832eb7f2a346c2f638d0