### PR TITLE
Ensure PagingSources use IO dispatcher

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
@@ -4,6 +4,8 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class ArtistsPagingSource(
     private val service: WikiArtService,
@@ -14,7 +16,9 @@ class ArtistsPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Artist> {
         return try {
             val page = params.key ?: 1
-            val result = service.fetchArtists(category, page, section)
+            val result = withContext(Dispatchers.IO) {
+                service.fetchArtists(category, page, section)
+            }
             val artists = result?.artists ?: emptyList()
             val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
             LoadResult.Page(

--- a/android/app/src/main/java/com/wikiart/SearchPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/SearchPagingSource.kt
@@ -2,6 +2,8 @@ package com.wikiart
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class SearchPagingSource(
     private val service: WikiArtService,
@@ -11,7 +13,9 @@ class SearchPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
         return try {
             val page = params.key ?: 1
-            val result = service.searchPaintings(term, page)
+            val result = withContext(Dispatchers.IO) {
+                service.searchPaintings(term, page)
+            }
             val paintings = result?.paintings ?: emptyList()
             val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
             LoadResult.Page(

--- a/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtPagingSource.kt
@@ -2,6 +2,8 @@ package com.wikiart
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class WikiArtPagingSource(
     private val service: WikiArtService,
@@ -12,7 +14,9 @@ class WikiArtPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
         return try {
             val page = params.key ?: 1
-            val result = service.fetchPaintings(category, page, sectionId)
+            val result = withContext(Dispatchers.IO) {
+                service.fetchPaintings(category, page, sectionId)
+            }
             val paintings = result?.paintings ?: emptyList()
             val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
             LoadResult.Page(


### PR DESCRIPTION
## Summary
- execute WikiArt service calls on `Dispatchers.IO` in all PagingSources
- import coroutine utilities

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c9c8808832e9ebf6cb2c3b3985f