### PR TITLE
Fix duplicate imports in ArtistsPagingSource

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsPagingSource.kt
@@ -2,8 +2,6 @@ package com.wikiart
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
## Summary
- remove redundant coroutine imports from `ArtistsPagingSource`

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_684b4fb1fd74832e9726b38a2e02193d