### PR TITLE
Update README for Android-only repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WikiArt Mobile
 
-This repository contains the original iOS project and an Android port.
+This repository originally contained both an iOS project and an Android port.
+The iOS project has been removed, leaving only the Android source code.
 
-* `WikiArt3.0` – iOS application written in Swift.
-* `android` – Android port written in Kotlin.
+* `android` – Android application written in Kotlin.
 
 The Android port now displays paintings retrieved from the WikiArt API with
 endless scrolling support powered by the Paging library. A category spinner


### PR DESCRIPTION
## Summary
- clarify that the iOS project was removed and only Android remains in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4fb00734832e9cdebe9971d3ab49