### PR TITLE
Fix layout jitter by reserving image space

### DIFF
--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -14,7 +14,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
-            android:scaleType="fitCenter" />
+            android:scaleType="fitCenter"
+            android:minHeight="@dimen/image_min_height_large" />
 
         <TextView
             android:id="@+id/artistName"

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -16,7 +16,8 @@
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
             android:transitionName="detailImage"
-            android:scaleType="fitCenter" />
+            android:scaleType="fitCenter"
+            android:minHeight="@dimen/image_min_height_large" />
 
         <TextView
             android:id="@+id/detailTitle"

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -10,7 +10,8 @@
         android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:scaleType="fitCenter" />
+        android:scaleType="fitCenter"
+        android:minHeight="@dimen/image_min_height_small" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/item_painting_sheet.xml
+++ b/android/app/src/main/res/layout/item_painting_sheet.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:scaleType="fitCenter" />
+        android:scaleType="fitCenter"
+        android:minHeight="@dimen/image_min_height_standard" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -10,7 +10,8 @@
         android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:scaleType="fitCenter" />
+        android:scaleType="fitCenter"
+        android:minHeight="@dimen/image_min_height_small" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/list_item_artist.xml
+++ b/android/app/src/main/res/layout/list_item_artist.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:scaleType="fitCenter" />
+        android:scaleType="fitCenter"
+        android:minHeight="@dimen/image_min_height_standard" />
 
     <TextView
         android:id="@+id/artistName"

--- a/android/app/src/main/res/layout/list_item_painting.xml
+++ b/android/app/src/main/res/layout/list_item_painting.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:scaleType="fitCenter" />
+        android:scaleType="fitCenter"
+        android:minHeight="@dimen/image_min_height_standard" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <dimen name="image_min_height_standard">180dp</dimen>
+    <dimen name="image_min_height_small">120dp</dimen>
+    <dimen name="image_min_height_large">240dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- create a `dimens.xml` file with placeholder heights
- reserve space for images in painting list, grid, sheet and related items
- reserve space for artist list and detail screens
- apply same fix for painting detail screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b51214608832eb180e4fd0e311b59