### PR TITLE
Make painting image fill width

### DIFF
--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -7,8 +7,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/detailImage"
@@ -17,6 +16,12 @@
             android:adjustViewBounds="true"
             android:transitionName="detailImage"
             android:scaleType="fitCenter" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
 
         <TextView
             android:id="@+id/detailTitle"
@@ -93,5 +98,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:scrollbars="horizontal" />
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- make the painting image go edge-to-edge on the detail screen

## Testing
- `sh gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b51b5bacc832e80c34bc7afb7cb0b