### PR TITLE
Display paintings in two-column grid

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -35,10 +35,14 @@ class PaintingAdapter(
 
     inner class PaintingViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val titleText: TextView = itemView.findViewById(R.id.titleText)
+        private val artistText: TextView? = itemView.findViewById(R.id.artistText)
+        private val yearText: TextView? = itemView.findViewById(R.id.yearText)
         private val paintingImage: ImageView = itemView.findViewById(R.id.paintingImage)
 
         fun bind(painting: Painting) {
             titleText.text = painting.title
+            artistText?.text = painting.artistName
+            yearText?.text = painting.year
             paintingImage.load(painting.image)
 
             itemView.setOnClickListener { onItemClick(painting) }

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 class PaintingsFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: PaintingAdapter
-    private var layoutType: LayoutType = LayoutType.LIST
+    private var layoutType: LayoutType = LayoutType.COLUMN
 
     private val itemClick: (Painting) -> Unit = { painting ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
@@ -54,8 +54,8 @@ class PaintingsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val prefs = requireContext().getSharedPreferences("prefs", Context.MODE_PRIVATE)
-        val name = prefs.getString("layout_type", LayoutType.LIST.name) ?: LayoutType.LIST.name
-        layoutType = runCatching { LayoutType.valueOf(name) }.getOrDefault(LayoutType.LIST)
+        val name = prefs.getString("layout_type", LayoutType.COLUMN.name) ?: LayoutType.COLUMN.name
+        layoutType = runCatching { LayoutType.valueOf(name) }.getOrDefault(LayoutType.COLUMN)
 
         recyclerView = view.findViewById(R.id.paintingRecyclerView)
         adapter = PaintingAdapter(layoutType, itemClick)

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="4dp">
+    android:padding="4dp"
+    android:gravity="center_horizontal">
 
     <ImageView
         android:id="@+id/paintingImage"
-        android:layout_width="120dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter" />
@@ -17,5 +18,20 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+
+    <TextView
+        android:id="@+id/artistText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+
+    <TextView
+        android:id="@+id/yearText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
         android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- default to two-column layout for painting lists
- show painting title, artist and year in grid items
- center painting images with preserved aspect ratio

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b52656880832eab7bdd3d2024bf6d