### PR TITLE
Update paging to defer downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The iOS project has been removed, leaving only the Android source code.
 * `android` – Android application written in Kotlin.
 
 The Android port now displays paintings retrieved from the WikiArt API with
-endless scrolling support powered by the Paging library. A category spinner
+endless scrolling support powered by the Paging library. Only one page of
+results is fetched at a time and the next page loads after most of the current
+items have been scrolled through. A category spinner
 lets you filter paintings (e.g. Featured or Popular). List items load images
 using Coil, and tapping an item opens a detail screen. You can search with
 autocomplete suggestions, mark paintings as favourites, view artist details and

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -13,6 +13,14 @@ import com.wikiart.model.ArtistSection
 
 class PaintingRepository(private val service: WikiArtService = WikiArtService()) {
 
+    private val pageSize = 20
+    private val prefetchDistance = 5
+    private val pagingConfig = PagingConfig(
+        pageSize = pageSize,
+        prefetchDistance = prefetchDistance,
+        initialLoadSize = pageSize
+    )
+
     suspend fun getPaintings(
         category: PaintingCategory,
         page: Int = 1,
@@ -23,7 +31,7 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         }
 
     fun pagingFlow(category: PaintingCategory, sectionId: String? = null): Flow<PagingData<Painting>> =
-        Pager(PagingConfig(pageSize = 20)) {
+        Pager(pagingConfig) {
             WikiArtPagingSource(service, category, sectionId)
         }.flow
 
@@ -33,7 +41,7 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         }
 
     fun searchPagingFlow(term: String): Flow<PagingData<Painting>> =
-        Pager(PagingConfig(pageSize = 20)) {
+        Pager(pagingConfig) {
             SearchPagingSource(service, term)
         }.flow
 
@@ -58,7 +66,7 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         }
 
     fun artistsPagingFlow(category: ArtistCategory, section: String? = null): Flow<PagingData<Artist>> =
-        Pager(PagingConfig(pageSize = 20)) {
+        Pager(pagingConfig) {
             ArtistsPagingSource(service, category, section)
         }.flow
 


### PR DESCRIPTION
## Summary
- customize `PagingConfig` to fetch only one page at a time
- update README to explain when pages are loaded

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b53484078832e9c705cea6046adfa