### PR TITLE
Add expandable details for artist info

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -35,10 +35,14 @@ class ArtistDetailActivity : AppCompatActivity() {
         recycler.adapter = adapter
 
         val bioView: TextView = findViewById(R.id.artistBio)
+        val birthView: TextView = findViewById(R.id.artistBirth)
+        val deathView: TextView = findViewById(R.id.artistDeath)
         val bioToggle: TextView = findViewById(R.id.bioToggle)
         bioToggle.setOnClickListener {
             bioExpanded = !bioExpanded
             bioView.maxLines = if (bioExpanded) Int.MAX_VALUE else 3
+            birthView.visibility = if (bioExpanded && birthView.text.isNotBlank()) View.VISIBLE else View.GONE
+            deathView.visibility = if (bioExpanded && deathView.text.isNotBlank()) View.VISIBLE else View.GONE
             bioToggle.text = getString(if (bioExpanded) R.string.show_less else R.string.show_more)
         }
 
@@ -52,9 +56,13 @@ class ArtistDetailActivity : AppCompatActivity() {
             if (details != null) {
                 findViewById<TextView>(R.id.artistName).text = details.artistName
                 bioView.text = details.biography
+                birthView.text = details.birth?.let { getString(R.string.born, it) } ?: ""
+                deathView.text = details.death?.let { getString(R.string.died, it) } ?: ""
+                birthView.visibility = if (bioExpanded && birthView.text.isNotBlank()) View.VISIBLE else View.GONE
+                deathView.visibility = if (bioExpanded && deathView.text.isNotBlank()) View.VISIBLE else View.GONE
                 findViewById<ImageView>(R.id.artistImage).load(details.image)
                 bioView.post {
-                    if (bioView.lineCount <= 3) {
+                    if (bioView.lineCount <= 3 && birthView.text.isBlank() && deathView.text.isBlank()) {
                         bioToggle.visibility = View.GONE
                     }
                 }

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -25,6 +25,21 @@
             android:textAppearance="@style/HeadingText" />
 
         <TextView
+            android:id="@+id/artistBirth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/BodyText"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/artistDeath"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/BodyText"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/artistBio"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -41,4 +41,6 @@
 
     <string name="show_more">Ver más</string>
     <string name="show_less">Ver menos</string>
+    <string name="born">Nacimiento: %1$s</string>
+    <string name="died">Fallecimiento: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -41,4 +41,6 @@
 
     <string name="show_more">Показать больше</string>
     <string name="show_less">Показать меньше</string>
+    <string name="born">Дата рождения: %1$s</string>
+    <string name="died">Дата смерти: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
 
     <string name="show_more">Show more</string>
     <string name="show_less">Show less</string>
+    <string name="born">Born: %1$s</string>
+    <string name="died">Died: %1$s</string>
 
     <string-array name="painting_category_names">
         <item>@string/painting_category_media</item>


### PR DESCRIPTION
## Summary
- extend artist details screen to show birth and death info
- keep biography collapsed by default and toggle to show more/less
- update translations

## Testing
- `sh gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5405f5f8832eab1b4eff9e7fe417