### PR TITLE
Fix grid item sizing for column layout

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -43,6 +43,16 @@ class PaintingAdapter(
             titleText.text = painting.title
             artistText?.text = painting.artistName
             yearText?.text = painting.year
+
+            if (layoutType == LayoutType.COLUMN) {
+                val dm = itemView.resources.displayMetrics
+                val itemWidth = dm.widthPixels / 2
+                val ratio = painting.height.toFloat() / painting.width.toFloat()
+                paintingImage.layoutParams = paintingImage.layoutParams.apply {
+                    height = (itemWidth * ratio).toInt()
+                }
+            }
+
             paintingImage.load(painting.image)
 
             itemView.setOnClickListener { onItemClick(painting) }


### PR DESCRIPTION
## Summary
- ensure grid items know their size before image load to keep rows aligned

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b55459b7c832ead7c4270945fd115