### PR TITLE
Update painting title text appearance

### DIFF
--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -29,7 +29,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:textAppearance="@style/HeadingText" />
+            android:textAppearance="@style/PaintingTitleText" />
 
         <TextView
             android:id="@+id/detailYear"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -18,6 +18,9 @@
 
     <!-- Custom text styles using Material typography -->
     <style name="HeadingText" parent="TextAppearance.Material3.TitleLarge" />
+    <style name="PaintingTitleText" parent="TextAppearance.Material3.DisplaySmall">
+        <item name="android:fontFamily">serif</item>
+    </style>
     <style name="BodyText" parent="TextAppearance.Material3.BodyLarge" />
     <style name="CaptionText" parent="TextAppearance.Material3.BodySmall" />
 


### PR DESCRIPTION
## Summary
- use a new `PaintingTitleText` style
- make the detail title serif and larger

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b570bd050832e9abd18d9037b9dcd