### PR TITLE
Center painting title

### DIFF
--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -26,9 +26,10 @@
 
         <TextView
             android:id="@+id/detailTitle"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:gravity="center"
             android:textAppearance="@style/HeadingText" />
 
         <TextView


### PR DESCRIPTION
## Summary
- align the painting title text to center on Android detail pages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b57d7c590832ea3ac36de33e83383