### PR TITLE
Add thumbnail URLs for paintings

### DIFF
--- a/android/app/src/main/java/com/wikiart/Painting.kt
+++ b/android/app/src/main/java/com/wikiart/Painting.kt
@@ -18,4 +18,26 @@ data class Painting(
     @SerializedName("paintingUrl") val paintingUrl: String,
     @SerializedName("artistUrl") val artistUrl: String?,
     @SerializedName("flags") val flags: Int
-) : Serializable
+) : Serializable {
+
+    private val extension: String
+        get() = image.substringAfterLast('.', "")
+
+    /**
+     * URL for a smaller thumbnail used in list views.
+     */
+    val thumbUrl: String
+        get() = "${image}!PinterestSmall.$extension"
+
+    /**
+     * URL for a larger image used in detail views.
+     */
+    val detailUrl: String
+        get() = "${image}!Blog.$extension"
+
+    /**
+     * URL for the original full size image.
+     */
+    val fullUrl: String
+        get() = image
+}

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -53,7 +53,7 @@ class PaintingAdapter(
                 }
             }
 
-            paintingImage.load(painting.image)
+            paintingImage.load(painting.thumbUrl)
 
             itemView.setOnClickListener { onItemClick(painting) }
         }

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -29,14 +29,15 @@ class PaintingDetailActivity : AppCompatActivity() {
         val painting = intent.getSerializableExtra(EXTRA_PAINTING) as? Painting
 
         val title = painting?.title ?: intent.getStringExtra(EXTRA_TITLE) ?: ""
-        val imageUrl = painting?.image ?: intent.getStringExtra(EXTRA_IMAGE) ?: ""
+        val imageUrl = painting?.detailUrl ?: intent.getStringExtra(EXTRA_IMAGE) ?: ""
+        val fullUrl = painting?.fullUrl ?: painting?.image ?: imageUrl
 
         findViewById<TextView>(R.id.detailTitle).text = title
         val detailImage: ImageView = findViewById(R.id.detailImage)
         detailImage.load(imageUrl)
         detailImage.setOnClickListener {
             val intent = Intent(this, ImageDetailActivity::class.java)
-            intent.putExtra(ImageDetailActivity.EXTRA_IMAGE_URL, imageUrl)
+            intent.putExtra(ImageDetailActivity.EXTRA_IMAGE_URL, fullUrl)
             val options = ActivityOptions.makeSceneTransitionAnimation(
                 this,
                 detailImage,
@@ -131,7 +132,7 @@ class PaintingDetailActivity : AppCompatActivity() {
         buyButton.setOnClickListener {
             painting ?: return@setOnClickListener
             val intent = Intent(this, StoreActivity::class.java)
-            intent.putExtra(StoreActivity.EXTRA_IMAGE_URL, painting.image)
+            intent.putExtra(StoreActivity.EXTRA_IMAGE_URL, painting.fullUrl)
             val options = ActivityOptions.makeSceneTransitionAnimation(this)
             startActivity(intent, options.toBundle())
             overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)

--- a/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
@@ -28,7 +28,7 @@ class RelatedPaintingAdapter(
 
         fun bind(painting: Painting) {
             title.text = painting.title
-            image.load(painting.image)
+            image.load(painting.thumbUrl)
             itemView.setOnClickListener { onItemClick(painting) }
         }
     }

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -21,7 +21,7 @@ class SearchActivity : AppCompatActivity() {
     private val adapter = PaintingAdapter { painting ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
-        intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
+        intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.detailUrl)
         val options = ActivityOptions.makeSceneTransitionAnimation(this)
         startActivity(intent, options.toBundle())
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -24,7 +24,7 @@ class SearchFragment : Fragment() {
     private val adapter = PaintingAdapter { painting ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
-        intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.image)
+        intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.detailUrl)
         val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
         startActivity(intent, options.toBundle())
         requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)


### PR DESCRIPTION
## Summary
- derive multiple image sizes from the painting image URL
- show small thumbnails in list views
- load larger images on the detail page and full originals in fullscreen

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b57a72590832e801305bc51b02b8d