### PR TITLE
Fix uniform grid tile height

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -47,9 +47,10 @@ class PaintingAdapter(
             if (layoutType == LayoutType.COLUMN) {
                 val dm = itemView.resources.displayMetrics
                 val itemWidth = dm.widthPixels / 2
-                val ratio = painting.height.toFloat() / painting.width.toFloat()
                 paintingImage.layoutParams = paintingImage.layoutParams.apply {
-                    height = (itemWidth * ratio).toInt()
+                    // use a fixed 1:1 ratio so all grid items occupy
+                    // the same rectangular area
+                    height = itemWidth
                 }
             }
 


### PR DESCRIPTION
## Summary
- keep 2-column view for painting grid but make each tile the same size

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5a26c534832ebca52844908abb78