### PR TITLE
Show load errors via Snackbar

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.LoadState
+import com.google.android.material.snackbar.Snackbar
 import com.wikiart.model.ArtistCategory
 import com.wikiart.model.ArtistSection
 import kotlinx.coroutines.Job
@@ -42,6 +44,20 @@ class ArtistsFragment : Fragment() {
         val recycler: RecyclerView = view.findViewById(R.id.artistRecyclerView)
         recycler.layoutManager = GridLayoutManager(requireContext(), 2)
         recycler.adapter = adapter
+
+        adapter.addLoadStateListener { state ->
+            val error = when {
+                state.refresh is LoadState.Error -> state.refresh as LoadState.Error
+                state.append is LoadState.Error -> state.append as LoadState.Error
+                state.prepend is LoadState.Error -> state.prepend as LoadState.Error
+                else -> null
+            }
+            error?.let {
+                Snackbar.make(view, R.string.load_error, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.retry) { adapter.retry() }
+                    .show()
+            }
+        }
 
         val spinner: Spinner = view.findViewById(R.id.artistCategorySpinner)
         val categories = ArtistCategory.values()

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import androidx.paging.LoadState
+import com.google.android.material.snackbar.Snackbar
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -61,6 +63,20 @@ class PaintingsFragment : Fragment() {
         adapter = PaintingAdapter(layoutType, itemClick)
         recyclerView.layoutManager = layoutManagerFor(layoutType)
         recyclerView.adapter = adapter
+
+        adapter.addLoadStateListener { state ->
+            val error = when {
+                state.refresh is LoadState.Error -> state.refresh as LoadState.Error
+                state.append is LoadState.Error -> state.append as LoadState.Error
+                state.prepend is LoadState.Error -> state.prepend as LoadState.Error
+                else -> null
+            }
+            error?.let {
+                Snackbar.make(view, R.string.load_error, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.retry) { adapter.retry() }
+                    .show()
+            }
+        }
 
         val spinner: Spinner = view.findViewById(R.id.categorySpinner)
         val categories = PaintingCategory.values()

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -16,6 +16,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.LoadState
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -43,6 +45,20 @@ class SearchFragment : Fragment() {
         val recyclerView: RecyclerView = view.findViewById(R.id.resultsRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
+
+        adapter.addLoadStateListener { state ->
+            val error = when {
+                state.refresh is LoadState.Error -> state.refresh as LoadState.Error
+                state.append is LoadState.Error -> state.append as LoadState.Error
+                state.prepend is LoadState.Error -> state.prepend as LoadState.Error
+                else -> null
+            }
+            error?.let {
+                Snackbar.make(view, R.string.load_error, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.retry) { adapter.retry() }
+                    .show()
+            }
+        }
 
         val suggestions = ArrayAdapter<String>(requireContext(), android.R.layout.simple_dropdown_item_1line)
         input.setAdapter(suggestions)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
 
     <string name="search">Search</string>
     <string name="unable_load_products">Unable to load products</string>
+    <string name="load_error">Unable to load content</string>
+    <string name="retry">Retry</string>
 
     <string name="painting_category_media">Media</string>
     <string name="painting_category_style">Style</string>


### PR DESCRIPTION
## Summary
- show snackbar with retry when paging errors occur
- add new error and retry strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5c1e3d5c832e86cd06ae1e516d5c