### PR TITLE
Add artist paintings screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
             android:theme="@style/FullScreenTheme" />
         <activity android:name=".ArtistDetailActivity" />
         <activity android:name=".ArtistsActivity" />
+        <activity android:name=".ArtistPaintingsActivity" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -49,6 +49,14 @@ class ArtistDetailActivity : AppCompatActivity() {
         val artistUrl = intent.getStringExtra(EXTRA_ARTIST_URL) ?: return
         val artistName = intent.getStringExtra(EXTRA_ARTIST_NAME) ?: ""
 
+        findViewById<com.google.android.material.button.MaterialButton>(R.id.seeAllButton).setOnClickListener {
+            val intent = android.content.Intent(this, ArtistPaintingsActivity::class.java)
+            intent.putExtra(ArtistPaintingsActivity.EXTRA_ARTIST_URL, artistUrl)
+            val options = ActivityOptions.makeSceneTransitionAnimation(this)
+            startActivity(intent, options.toBundle())
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+        }
+
         findViewById<TextView>(R.id.artistName).text = artistName
 
         lifecycleScope.launch {

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
@@ -1,0 +1,46 @@
+package com.wikiart
+
+import android.app.ActivityOptions
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.cachedIn
+import kotlinx.coroutines.launch
+
+class ArtistPaintingsActivity : AppCompatActivity() {
+    private val adapter = PaintingAdapter { painting ->
+        val intent = Intent(this, PaintingDetailActivity::class.java)
+        intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        startActivity(intent, options.toBundle())
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+    }
+
+    private val repository = PaintingRepository()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_artist_paintings)
+
+        val recyclerView: RecyclerView = findViewById(R.id.allPaintingsRecyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        val url = intent.getStringExtra(EXTRA_ARTIST_URL) ?: return
+
+        lifecycleScope.launch {
+            repository.artistPaintingsPagingFlow(url)
+                .cachedIn(lifecycleScope)
+                .collect { pagingData ->
+                    adapter.submitData(pagingData)
+                }
+        }
+    }
+
+    companion object {
+        const val EXTRA_ARTIST_URL = "extra_artist_url"
+    }
+}

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsPagingSource.kt
@@ -1,0 +1,37 @@
+package com.wikiart
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ArtistPaintingsPagingSource(
+    private val service: WikiArtService,
+    private val path: String
+) : PagingSource<Int, Painting>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
+        return try {
+            val page = params.key ?: 1
+            val result = withContext(Dispatchers.IO) {
+                service.fetchAllPaintingsByDate(path, page)
+            }
+            val paintings = result?.paintings ?: emptyList()
+            val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null
+            LoadResult.Page(
+                data = paintings,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Painting>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            state.closestPageToPosition(anchor)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchor)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -69,6 +69,11 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         Pager(pagingConfig) {
             ArtistsPagingSource(service, category, section)
         }.flow
+    fun artistPaintingsPagingFlow(path: String): Flow<PagingData<Painting>> =
+        Pager(pagingConfig) {
+            ArtistPaintingsPagingSource(service, path)
+        }.flow
+
 
     suspend fun artistSections(category: ArtistCategory): List<ArtistSection> =
         withContext(Dispatchers.IO) {

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -141,6 +141,21 @@ class WikiArtService(
         }
     }
 
+    fun fetchAllPaintingsByDate(path: String, page: Int = 1): PaintingList? {
+        val cleanPath = if (path.startsWith("http")) path else "${serverConfig.apiBaseUrl}$path"
+        val url = "$cleanPath/all-works?page=$page&json=2"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            Log.d(TAG, "fetchAllPaintingsByDate response: $body")
+            val result = gson.fromJson(body, PaintingList::class.java)
+            Log.d(TAG, "fetchAllPaintingsByDate decoded: $result")
+            return result
+        }
+    }
+
+
 
     fun fetchSections(category: PaintingCategory): List<PaintingSection>? {
         val group = when (category) {

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -62,5 +62,15 @@
             android:layout_marginTop="8dp"
             android:nestedScrollingEnabled="false"
             android:scrollbars="horizontal" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/seeAllButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/see_all_paintings"
+            style="@style/Widget.Material3.Button"
+            android:backgroundTint="?attr/colorPrimary"
+            android:textColor="@android:color/white"
+            android:foreground="?attr/selectableItemBackground" />
     </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/layout/activity_artist_paintings.xml
+++ b/android/app/src/main/res/layout/activity_artist_paintings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/allPaintingsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -41,6 +41,7 @@
 
     <string name="show_more">Ver más</string>
     <string name="show_less">Ver menos</string>
+    <string name="see_all_paintings">Ver todas las pinturas</string>
     <string name="born">Nacimiento: %1$s</string>
     <string name="died">Fallecimiento: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -41,6 +41,7 @@
 
     <string name="show_more">Показать больше</string>
     <string name="show_less">Показать меньше</string>
+    <string name="see_all_paintings">Посмотреть все картины</string>
     <string name="born">Дата рождения: %1$s</string>
     <string name="died">Дата смерти: %1$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
 
     <string name="show_more">Show more</string>
     <string name="show_less">Show less</string>
+    <string name="see_all_paintings">See all paintings</string>
     <string name="born">Born: %1$s</string>
     <string name="died">Died: %1$s</string>
 

--- a/android/app/src/test/java/com/wikiart/ArtistPaintingsPagingSourceTest.kt
+++ b/android/app/src/test/java/com/wikiart/ArtistPaintingsPagingSourceTest.kt
@@ -1,0 +1,41 @@
+import androidx.paging.PagingSource
+import com.wikiart.ArtistPaintingsPagingSource
+import com.wikiart.WikiArtService
+import com.wikiart.PaintingList
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistPaintingsPagingSourceTest {
+    @Test
+    fun loadHandlesEmptyResponse() = runBlocking {
+        val service = mockk<WikiArtService>()
+        coEvery { service.fetchAllPaintingsByDate("/foo", 1) } returns
+            PaintingList(emptyList(), 0, 20)
+
+        val source = ArtistPaintingsPagingSource(service, "/foo")
+        val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
+        val result = source.load(params)
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        result as PagingSource.LoadResult.Page
+        assertTrue(result.data.isEmpty())
+        assertEquals(null, result.prevKey)
+        assertEquals(null, result.nextKey)
+    }
+
+    @Test
+    fun loadReturnsError() = runBlocking {
+        val service = mockk<WikiArtService>()
+        coEvery { service.fetchAllPaintingsByDate("/foo", 1) } throws RuntimeException("boom")
+
+        val source = ArtistPaintingsPagingSource(service, "/foo")
+        val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
+        val result = source.load(params)
+
+        assertTrue(result is PagingSource.LoadResult.Error)
+    }
+}

--- a/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
@@ -3,6 +3,7 @@ import com.wikiart.PaintingRepository
 import com.wikiart.PaintingCategory
 import com.wikiart.WikiArtPagingSource
 import com.wikiart.WikiArtService
+import com.wikiart.ArtistPaintingsPagingSource
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -30,5 +31,24 @@ class PaintingRepositoryTest {
         assertEquals(service, serviceField.get(source))
         assertEquals(PaintingCategory.FEATURED, categoryField.get(source))
         assertEquals("section", sectionField.get(source))
+    }
+    @Test
+    fun artistPaintingsPagingFlowCreatesSource() {
+        val service = mockk<WikiArtService>(relaxed = true)
+        val repo = PaintingRepository(service)
+        val flow = repo.artistPaintingsPagingFlow("/foo")
+
+        val field = flow.javaClass.getDeclaredField("this$0")
+        field.isAccessible = true
+        val pager = field.get(flow) as Pager<*, *>
+        val source = pager.pagingSourceFactory.invoke()
+        assertTrue(source is ArtistPaintingsPagingSource)
+
+        val serviceField = ArtistPaintingsPagingSource::class.java.getDeclaredField("service")
+        val pathField = ArtistPaintingsPagingSource::class.java.getDeclaredField("path")
+        serviceField.isAccessible = true
+        pathField.isAccessible = true
+        assertEquals(service, serviceField.get(source))
+        assertEquals("/foo", pathField.get(source))
     }
 }


### PR DESCRIPTION
## Summary
- allow paging through all paintings for an artist
- fetch all paintings in `WikiArtService`
- add button on artist details screen
- support new screen `ArtistPaintingsActivity`
- localize "See all paintings"
- cover new behaviour with tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5a8e3fb0832e9066883a03882f29