### PR TITLE
Adjust grid layout padding

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -47,10 +47,13 @@ class PaintingAdapter(
             if (layoutType == LayoutType.COLUMN) {
                 val dm = itemView.resources.displayMetrics
                 val itemWidth = dm.widthPixels / 2
+                val padding = itemView.resources.getDimensionPixelSize(
+                    R.dimen.painting_grid_image_padding
+                ) * 2
                 paintingImage.layoutParams = paintingImage.layoutParams.apply {
                     // use a fixed 1:1 ratio so all grid items occupy
-                    // the same rectangular area
-                    height = itemWidth
+                    // the same rectangular area, accounting for padding
+                    height = itemWidth - padding
                 }
             }
 

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -10,6 +10,7 @@
         android:id="@+id/paintingImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/painting_grid_image_padding"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
         android:minHeight="@dimen/image_min_height_small" />

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -2,4 +2,6 @@
     <dimen name="image_min_height_standard">180dp</dimen>
     <dimen name="image_min_height_small">120dp</dimen>
     <dimen name="image_min_height_large">240dp</dimen>
+    <!-- Padding around painting images in the two-column grid layout -->
+    <dimen name="painting_grid_image_padding">30dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- add a dimension value for grid image padding
- pad grid painting images with the new dimension
- keep images square after padding

## Testing
- `sh gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5e8f28f4832ea6c9b9eaeaf918e3