### PR TITLE
Add sorting and layout options for artist paintings

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
@@ -8,10 +8,26 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.cachedIn
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+import android.view.Menu
+import android.view.MenuItem
+import android.content.Context
+import android.view.View
+import android.widget.AdapterView
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import androidx.paging.LoadState
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.wikiart.model.LayoutType
+import com.wikiart.model.ArtistPaintingSort
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class ArtistPaintingsActivity : AppCompatActivity() {
-    private val adapter = PaintingAdapter { painting ->
+    private var layoutType: LayoutType = LayoutType.SHEET
+    private var sort: ArtistPaintingSort = ArtistPaintingSort.DATE
+    private val adapter = PaintingAdapter(layoutType) { painting ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
         val options = ActivityOptions.makeSceneTransitionAnimation(this)
@@ -20,19 +36,76 @@ class ArtistPaintingsActivity : AppCompatActivity() {
     }
 
     private val repository = PaintingRepository()
+    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
+    private var pagingJob: Job? = null
+
+    private lateinit var artistUrl: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_artist_paintings)
 
+        val prefs = getSharedPreferences("prefs", Context.MODE_PRIVATE)
+        val name = prefs.getString("layout_type", LayoutType.SHEET.name) ?: LayoutType.SHEET.name
+        layoutType = runCatching { LayoutType.valueOf(name) }.getOrDefault(LayoutType.SHEET)
+
+        swipeRefreshLayout = findViewById(R.id.swipeRefreshLayout)
         val recyclerView: RecyclerView = findViewById(R.id.allPaintingsRecyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.layoutManager = layoutManagerFor(layoutType)
         recyclerView.adapter = adapter
 
-        val url = intent.getStringExtra(EXTRA_ARTIST_URL) ?: return
+        val sortSpinner: Spinner = findViewById(R.id.sortSpinner)
+        val sortNames = resources.getStringArray(R.array.artist_painting_sort_names)
+        sortSpinner.adapter = ArrayAdapter(this, R.layout.spinner_sort_item, sortNames)
+        sortSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                sort = ArtistPaintingSort.values()[position]
+                loadPaintings()
+            }
 
-        lifecycleScope.launch {
-            repository.artistPaintingsPagingFlow(url)
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+
+        swipeRefreshLayout.setOnRefreshListener { adapter.refresh() }
+        adapter.addLoadStateListener { loadState ->
+            swipeRefreshLayout.isRefreshing = loadState.source.refresh is LoadState.Loading
+        }
+
+        artistUrl = intent.getStringExtra(EXTRA_ARTIST_URL) ?: return
+
+        loadPaintings()
+    }
+
+    private fun layoutManagerFor(type: LayoutType): RecyclerView.LayoutManager = when (type) {
+        LayoutType.COLUMN -> GridLayoutManager(this, 2)
+        LayoutType.SHEET -> StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
+        else -> LinearLayoutManager(this)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.layout_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        val prefs = getSharedPreferences("prefs", Context.MODE_PRIVATE)
+        layoutType = when (item.itemId) {
+            R.id.layout_list -> LayoutType.LIST
+            R.id.layout_grid -> LayoutType.COLUMN
+            R.id.layout_sheet -> LayoutType.SHEET
+            else -> return super.onOptionsItemSelected(item)
+        }
+        prefs.edit().putString("layout_type", layoutType.name).apply()
+        adapter.layoutType = layoutType
+        adapter.notifyDataSetChanged()
+        findViewById<RecyclerView>(R.id.allPaintingsRecyclerView).layoutManager = layoutManagerFor(layoutType)
+        return true
+    }
+
+    private fun loadPaintings() {
+        pagingJob?.cancel()
+        pagingJob = lifecycleScope.launch {
+            repository.artistPaintingsPagingFlow(artistUrl, sort)
                 .cachedIn(lifecycleScope)
                 .collect { pagingData ->
                     adapter.submitData(pagingData)

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsPagingSource.kt
@@ -7,14 +7,19 @@ import kotlinx.coroutines.withContext
 
 class ArtistPaintingsPagingSource(
     private val service: WikiArtService,
-    private val path: String
+    private val path: String,
+    private val sort: com.wikiart.model.ArtistPaintingSort = com.wikiart.model.ArtistPaintingSort.DATE
 ) : PagingSource<Int, Painting>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Painting> {
         return try {
             val page = params.key ?: 1
             val result = withContext(Dispatchers.IO) {
-                service.fetchAllPaintingsByDate(path, page)
+                when (sort) {
+                    com.wikiart.model.ArtistPaintingSort.NAME ->
+                        service.fetchAllPaintingsByAlphabet(path, page)
+                    else -> service.fetchAllPaintingsByDate(path, page)
+                }
             }
             val paintings = result?.paintings ?: emptyList()
             val nextKey = if (page < (result?.pageCount ?: page)) page + 1 else null

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -69,9 +69,12 @@ class PaintingRepository(private val service: WikiArtService = WikiArtService())
         Pager(pagingConfig) {
             ArtistsPagingSource(service, category, section)
         }.flow
-    fun artistPaintingsPagingFlow(path: String): Flow<PagingData<Painting>> =
+    fun artistPaintingsPagingFlow(
+        path: String,
+        sort: com.wikiart.model.ArtistPaintingSort = com.wikiart.model.ArtistPaintingSort.DATE
+    ): Flow<PagingData<Painting>> =
         Pager(pagingConfig) {
-            ArtistPaintingsPagingSource(service, path)
+            ArtistPaintingsPagingSource(service, path, sort)
         }.flow
 
 

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -155,6 +155,20 @@ class WikiArtService(
         }
     }
 
+    fun fetchAllPaintingsByAlphabet(path: String, page: Int = 1): PaintingList? {
+        val cleanPath = if (path.startsWith("http")) path else "${serverConfig.apiBaseUrl}$path"
+        val url = "$cleanPath/mode/all-paintings-by-alphabet?page=$page&json=2"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            Log.d(TAG, "fetchAllPaintingsByAlphabet response: $body")
+            val result = gson.fromJson(body, PaintingList::class.java)
+            Log.d(TAG, "fetchAllPaintingsByAlphabet decoded: $result")
+            return result
+        }
+    }
+
 
 
     fun fetchSections(category: PaintingCategory): List<PaintingSection>? {

--- a/android/app/src/main/java/com/wikiart/model/ArtistPaintingSort.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistPaintingSort.kt
@@ -1,0 +1,7 @@
+package com.wikiart.model
+
+/** Sort options for artist paintings */
+enum class ArtistPaintingSort {
+    DATE,
+    NAME
+}

--- a/android/app/src/main/res/layout/activity_artist_paintings.xml
+++ b/android/app/src/main/res/layout/activity_artist_paintings.xml
@@ -4,8 +4,20 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/allPaintingsRecyclerView"
+    <Spinner
+        android:id="@+id/sortSpinner"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/allPaintingsRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/spinner_sort_item.xml
+++ b/android/app/src/main/res/layout/spinner_sort_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:padding="8dp"
+    android:textAppearance="@style/HeadingText" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -47,6 +47,14 @@
     <string name="artist_category_recent">Recent</string>
     <string name="artist_category_institution">Art Institution</string>
 
+    <string name="sort_by_date">By Date</string>
+    <string name="sort_by_name">By Name</string>
+
+    <string-array name="artist_painting_sort_names">
+        <item>@string/sort_by_date</item>
+        <item>@string/sort_by_name</item>
+    </string-array>
+
     <string name="show_more">Show more</string>
     <string name="show_less">Show less</string>
     <string name="see_all_paintings">See all paintings</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
     <style name="PaintingTitleText" parent="TextAppearance.Material3.DisplaySmall">
         <item name="android:fontFamily">serif</item>
         <item name="android:textColor">@android:color/black</item>
-        <item name="android:textSize">24sp</item>
+        <item name="android:textSize">22sp</item>
     </style>
     <style name="BodyText" parent="TextAppearance.Material3.BodyLarge" />
     <style name="CaptionText" parent="TextAppearance.Material3.BodySmall" />

--- a/android/app/src/test/java/com/wikiart/ArtistPaintingsPagingSourceTest.kt
+++ b/android/app/src/test/java/com/wikiart/ArtistPaintingsPagingSourceTest.kt
@@ -2,6 +2,7 @@ import androidx.paging.PagingSource
 import com.wikiart.ArtistPaintingsPagingSource
 import com.wikiart.WikiArtService
 import com.wikiart.PaintingList
+import com.wikiart.model.ArtistPaintingSort
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -16,7 +17,7 @@ class ArtistPaintingsPagingSourceTest {
         coEvery { service.fetchAllPaintingsByDate("/foo", 1) } returns
             PaintingList(emptyList(), 0, 20)
 
-        val source = ArtistPaintingsPagingSource(service, "/foo")
+        val source = ArtistPaintingsPagingSource(service, "/foo", ArtistPaintingSort.DATE)
         val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
         val result = source.load(params)
 
@@ -32,7 +33,7 @@ class ArtistPaintingsPagingSourceTest {
         val service = mockk<WikiArtService>()
         coEvery { service.fetchAllPaintingsByDate("/foo", 1) } throws RuntimeException("boom")
 
-        val source = ArtistPaintingsPagingSource(service, "/foo")
+        val source = ArtistPaintingsPagingSource(service, "/foo", ArtistPaintingSort.DATE)
         val params = PagingSource.LoadParams.Refresh<Int>(null, 20, false)
         val result = source.load(params)
 

--- a/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.wikiart.PaintingCategory
 import com.wikiart.WikiArtPagingSource
 import com.wikiart.WikiArtService
 import com.wikiart.ArtistPaintingsPagingSource
+import com.wikiart.model.ArtistPaintingSort
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -36,7 +37,7 @@ class PaintingRepositoryTest {
     fun artistPaintingsPagingFlowCreatesSource() {
         val service = mockk<WikiArtService>(relaxed = true)
         val repo = PaintingRepository(service)
-        val flow = repo.artistPaintingsPagingFlow("/foo")
+        val flow = repo.artistPaintingsPagingFlow("/foo", ArtistPaintingSort.DATE)
 
         val field = flow.javaClass.getDeclaredField("this$0")
         field.isAccessible = true
@@ -46,9 +47,12 @@ class PaintingRepositoryTest {
 
         val serviceField = ArtistPaintingsPagingSource::class.java.getDeclaredField("service")
         val pathField = ArtistPaintingsPagingSource::class.java.getDeclaredField("path")
+        val sortField = ArtistPaintingsPagingSource::class.java.getDeclaredField("sort")
         serviceField.isAccessible = true
         pathField.isAccessible = true
+        sortField.isAccessible = true
         assertEquals(service, serviceField.get(source))
         assertEquals("/foo", pathField.get(source))
+        assertEquals(ArtistPaintingSort.DATE, sortField.get(source))
     }
 }


### PR DESCRIPTION
## Summary
- support sorting artist paintings by date or name
- let all paintings screen change layout like on iOS
- tweak title fonts to match iOS style
- add tests for new sorting feature

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5ee35210832ebbf86c0e0cdabb0d