### PR TITLE
Sync Android text styles with iOS

### DIFF
--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -45,7 +45,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:maxLines="3"
-            android:ellipsize="end" />
+            android:ellipsize="end"
+            android:textAppearance="@style/BodyText" />
 
         <TextView
             android:id="@+id/bioToggle"

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -36,14 +36,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:visibility="gone" />
+            android:visibility="gone"
+            android:textAppearance="@style/BodyText" />
 
         <TextView
             android:id="@+id/detailDimensions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
-            android:visibility="gone" />
+            android:visibility="gone"
+            android:textAppearance="@style/BodyText" />
 
         <TextView
             android:id="@+id/detailArtist"

--- a/android/app/src/main/res/layout/activity_search.xml
+++ b/android/app/src/main/res/layout/activity_search.xml
@@ -8,7 +8,8 @@
         android:id="@+id/searchInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/search"/>
+        android:hint="@string/search"
+        android:textAppearance="@style/BodyText" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/resultsRecyclerView"

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -8,7 +8,8 @@
         android:id="@+id/searchInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/search"/>
+        android:hint="@string/search"
+        android:textAppearance="@style/BodyText" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -28,12 +28,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAlignment="center"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        android:textAppearance="@style/CaptionText" />
 
     <TextView
         android:id="@+id/yearText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAlignment="center"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        android:textAppearance="@style/CaptionText" />
 </LinearLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,7 @@
 <resources>
     <color name="colorPrimary">#6200EE</color>
     <color name="colorSecondary">#03DAC5</color>
+    <!-- Text colors aligned with iOS design -->
+    <color name="textDark">#000000</color>
+    <color name="textLight">#888888</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -17,14 +17,25 @@
 
 
     <!-- Custom text styles using Material typography -->
-    <style name="HeadingText" parent="TextAppearance.Material3.TitleLarge" />
+    <style name="HeadingText" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">@color/textDark</item>
+        <item name="android:textStyle">bold</item>
+    </style>
     <style name="PaintingTitleText" parent="TextAppearance.Material3.DisplaySmall">
         <item name="android:fontFamily">serif</item>
-        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColor">@color/textDark</item>
         <item name="android:textSize">24sp</item>
     </style>
-    <style name="BodyText" parent="TextAppearance.Material3.BodyLarge" />
-    <style name="CaptionText" parent="TextAppearance.Material3.BodySmall" />
+    <style name="BodyText" parent="TextAppearance.Material3.BodyLarge">
+        <item name="android:textSize">16sp</item>
+        <item name="android:textColor">@color/textDark</item>
+    </style>
+    <style name="CaptionText" parent="TextAppearance.Material3.BodySmall">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/textDark</item>
+        <item name="android:textStyle">italic</item>
+    </style>
 
     <style name="TextAppearance.BodyLarge" parent="TextAppearance.Material3.BodyLarge" />
 


### PR DESCRIPTION
## Summary
- add iOS-inspired text colors
- define Android text styles to match iOS fonts
- apply updated text appearances across layouts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f0f6810832eb7634b4ffa1e7238