### PR TITLE
Add pull-to-refresh for favourites

### DIFF
--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.PagingData
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.paging.LoadState
 import com.wikiart.data.FavoritesRepository
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -20,14 +22,20 @@ class FavoritesActivity : AppCompatActivity() {
         startActivity(intent, options.toBundle())
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
+    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_favorites)
 
+        swipeRefreshLayout = findViewById(R.id.swipeRefreshLayout)
         val recyclerView: RecyclerView = findViewById(R.id.favoritesRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = adapter
+        swipeRefreshLayout.setOnRefreshListener { adapter.refresh() }
+        adapter.addLoadStateListener { loadState ->
+            swipeRefreshLayout.isRefreshing = loadState.source.refresh is LoadState.Loading
+        }
 
         val repository = FavoritesRepository(this)
         lifecycleScope.launch {

--- a/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.paging.LoadState
 import com.wikiart.data.FavoritesRepository
 import kotlinx.coroutines.launch
 
@@ -22,6 +24,7 @@ class FavoritesFragment : Fragment() {
         startActivity(intent, options.toBundle())
         requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
+    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_favorites, container, false)
@@ -29,9 +32,14 @@ class FavoritesFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        swipeRefreshLayout = view.findViewById(R.id.swipeRefreshLayout)
         val recyclerView: RecyclerView = view.findViewById(R.id.favoritesRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
+        swipeRefreshLayout.setOnRefreshListener { adapter.refresh() }
+        adapter.addLoadStateListener { loadState ->
+            swipeRefreshLayout.isRefreshing = loadState.source.refresh is LoadState.Loading
+        }
 
         val repository = FavoritesRepository(requireContext())
         viewLifecycleOwner.lifecycleScope.launch {

--- a/android/app/src/main/res/layout/activity_favorites.xml
+++ b/android/app/src/main/res/layout/activity_favorites.xml
@@ -4,8 +4,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/favoritesRecyclerView"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/favoritesRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/fragment_favorites.xml
+++ b/android/app/src/main/res/layout/fragment_favorites.xml
@@ -4,8 +4,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/favoritesRecyclerView"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/favoritesRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add `SwipeRefreshLayout` to favourites layouts
- hook up refresh handling in `FavoritesFragment` and `FavoritesActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b62a3a6f4832eb10f05da5a8c18bb