### PR TITLE
Match Android painting design to iOS

### DIFF
--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -2,7 +2,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:transitionName="paintingDetail">
+    android:transitionName="paintingDetail"
+    android:background="@color/groupBackground">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_paintings.xml
+++ b/android/app/src/main/res/layout/fragment_paintings.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/groupBackground">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -28,7 +29,8 @@
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        android:background="@color/groupBackground">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/paintingRecyclerView"

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -3,8 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="4dp"
-    android:gravity="center_horizontal">
+    android:padding="8dp"
+    android:gravity="center_horizontal"
+    android:background="@color/cardBackground">
 
     <ImageView
         android:id="@+id/paintingImage"
@@ -13,7 +14,8 @@
         android:layout_margin="@dimen/painting_grid_image_padding"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:minHeight="@dimen/image_min_height_small" />
+        android:minHeight="@dimen/image_min_height_small"
+        android:background="@color/imagePlaceholder" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/item_painting_sheet.xml
+++ b/android/app/src/main/res/layout/item_painting_sheet.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="2dp">
+    android:padding="2dp"
+    android:background="@color/cardBackground">
 
     <ImageView
         android:id="@+id/paintingImage"
@@ -11,7 +12,8 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:minHeight="@dimen/image_min_height_standard" />
+        android:minHeight="@dimen/image_min_height_standard"
+        android:background="@color/imagePlaceholder" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -3,7 +3,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    android:background="@color/cardBackground">
 
     <ImageView
         android:id="@+id/paintingImage"
@@ -11,7 +12,8 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:minHeight="@dimen/image_min_height_small" />
+        android:minHeight="@dimen/image_min_height_small"
+        android:background="@color/imagePlaceholder" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/list_item_painting.xml
+++ b/android/app/src/main/res/layout/list_item_painting.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:background="@color/cardBackground">
 
     <ImageView
         android:id="@+id/paintingImage"
@@ -11,7 +12,8 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:minHeight="@dimen/image_min_height_standard" />
+        android:minHeight="@dimen/image_min_height_standard"
+        android:background="@color/imagePlaceholder" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,12 @@
 <resources>
-    <color name="colorPrimary">#6200EE</color>
-    <color name="colorSecondary">#03DAC5</color>
+    <!-- iOS style blue accent -->
+    <color name="colorPrimary">#0A84FF</color>
+    <color name="colorSecondary">#0A84FF</color>
     <!-- Text colors aligned with iOS design -->
     <color name="textDark">#000000</color>
     <color name="textLight">#888888</color>
+    <!-- Backgrounds matching iOS list appearance -->
+    <color name="groupBackground">#F2F2F7</color>
+    <color name="cardBackground">#FFFFFF</color>
+    <color name="imagePlaceholder">#C6C6C8</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -24,10 +24,8 @@
     </style>
     <style name="PaintingTitleText" parent="TextAppearance.Material3.DisplaySmall">
         <item name="android:fontFamily">serif</item>
-
         <item name="android:textColor">@color/textDark</item>
-        <item name="android:textSize">24sp</item>
-
+        <item name="android:textSize">22sp</item>
     </style>
     <style name="BodyText" parent="TextAppearance.Material3.BodyLarge">
         <item name="android:textSize">16sp</item>


### PR DESCRIPTION
## Summary
- update color resources with iOS palette
- tweak text style to use 22sp size like iOS
- set group background color on painting list and detail screens
- use white card backgrounds and grey image placeholders for painting items

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b658e83ec832eab06d1d839735c72