### PR TITLE
Align Android painting layouts with iOS design

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ share or buy prints of a painting. Images can also be viewed full screen with
 pinch‑to‑zoom and a Support screen lets you send feedback or donate via
 Google Play in‑app purchases. Section titles are localized using your device
 language with a fallback to English when needed.
+
+Paintings can be viewed in three layouts—list, grid and sheet—mirroring the
+iOS design. The list and grid layouts display the artist name, title and year
+beneath each image while the sheet layout shows only the artwork image.

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -18,25 +18,28 @@
         android:background="@color/imagePlaceholder" />
 
     <TextView
-        android:id="@+id/titleText"
+        android:id="@+id/artistText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:gravity="center"
         android:textAlignment="center"
-        android:textAppearance="@style/PaintingTitleText" />
+        android:textAppearance="@style/CaptionText" />
 
     <TextView
-        android:id="@+id/artistText"
+        android:id="@+id/titleText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:gravity="center"
         android:textAlignment="center"
-        android:textAppearance="@style/CaptionText" />
+        android:textAppearance="@style/PaintingTitleText" />
 
     <TextView
         android:id="@+id/yearText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
         android:textAlignment="center"
         android:textAppearance="@style/CaptionText" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/item_painting_sheet.xml
+++ b/android/app/src/main/res/layout/item_painting_sheet.xml
@@ -21,5 +21,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:gravity="center"
+        android:visibility="gone"
         android:textAppearance="@style/PaintingTitleText" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/list_item_painting.xml
+++ b/android/app/src/main/res/layout/list_item_painting.xml
@@ -16,10 +16,26 @@
         android:background="@color/imagePlaceholder" />
 
     <TextView
-        android:id="@+id/titleText"
+        android:id="@+id/artistText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:gravity="center"
+        android:textAppearance="@style/CaptionText" />
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:gravity="center"
         android:textAppearance="@style/PaintingTitleText" />
+
+    <TextView
+        android:id="@+id/yearText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:gravity="center"
+        android:textAppearance="@style/CaptionText" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- hide text in sheet layout so it shows only the image
- show artist and year in the list layout
- reorder grid layout fields to artist, title then year
- document the three layout options

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b68ae7f84832e8021703cba375d21