### PR TITLE
Improve Android theme to match iOS

### DIFF
--- a/android/app/src/main/res/color/nav_item_color.xml
+++ b/android/app/src/main/res/color/nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorPrimary" android:state_checked="true" />
+    <item android:color="@color/textLight" />
+</selector>

--- a/android/app/src/main/res/drawable/ic_artists.xml
+++ b/android/app/src/main/res/drawable/ic_artists.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
 </vector>

--- a/android/app/src/main/res/drawable/ic_favorite_border.xml
+++ b/android/app/src/main/res/drawable/ic_favorite_border.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M16.5 3c-1.74 0-3.41.81-4.5 2.09C10.91 3.81 9.24 3 7.5 3 4.42 3 2 5.42 2 8.5c0 3.78 3.4 6.86 8.55 11.54L12 21.35l1.45-1.32C18.6 15.36 22 12.28 22 8.5 22 5.42 19.58 3 16.5 3zm-4.4 15.55l-.1.1-.1-.1C7.14 14.24 4 11.39 4 8.5 4 6.5 5.5 5 7.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5c2 0 3.5 1.5 3.5 3.5 0 2.89-3.14 5.74-7.9 10.05z" />
 </vector>

--- a/android/app/src/main/res/drawable/ic_favorite_filled.xml
+++ b/android/app/src/main/res/drawable/ic_favorite_filled.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
 </vector>

--- a/android/app/src/main/res/drawable/ic_gallery.xml
+++ b/android/app/src/main/res/drawable/ic_gallery.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M22 16V4c0-1.1-.9-2-2-2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2zm-11-4l2.03 2.71L16 11l4 5H8l3-4zM2 6v14c0 1.1.9 2 2 2h14v-2H4V6H2z"/>
 </vector>

--- a/android/app/src/main/res/drawable/ic_search.xml
+++ b/android/app/src/main/res/drawable/ic_search.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
 </vector>

--- a/android/app/src/main/res/drawable/ic_support.xml
+++ b/android/app/src/main/res/drawable/ic_support.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
 </vector>

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -54,7 +54,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:text="@string/show_more"
-            android:textColor="@android:color/holo_blue_dark" />
+            android:textColor="@color/colorPrimary" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/famousRecyclerView"

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -15,5 +15,8 @@
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/cardBackground"
+        app:itemTextColor="@color/nav_item_color"
+        app:itemIconTint="@color/nav_item_color"
         app:menu="@menu/bottom_nav_menu" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -53,7 +53,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:textColor="@android:color/holo_blue_dark"
+            android:textColor="@color/colorPrimary"
             android:textStyle="bold" />
 
         <ImageButton

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,9 +1,9 @@
 <resources>
-    <dimen name="image_min_height_standard">180dp</dimen>
-    <dimen name="image_min_height_small">120dp</dimen>
-    <dimen name="image_min_height_large">240dp</dimen>
+    <dimen name="image_min_height_standard">200dp</dimen>
+    <dimen name="image_min_height_small">150dp</dimen>
+    <dimen name="image_min_height_large">300dp</dimen>
     <!-- Taller artist cell height to match iOS aspect ratio -->
     <dimen name="artist_image_min_height">320dp</dimen>
     <!-- Padding around painting images in the two-column grid layout -->
-    <dimen name="painting_grid_image_padding">30dp</dimen>
+    <dimen name="painting_grid_image_padding">16dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -18,30 +18,30 @@
 
     <!-- Custom text styles using Material typography -->
     <style name="HeadingText" parent="TextAppearance.Material3.TitleLarge">
-        <item name="android:textSize">18sp</item>
+        <item name="android:textSize">20sp</item>
         <item name="android:textColor">@color/textDark</item>
         <item name="android:textStyle">bold</item>
     </style>
     <style name="PaintingTitleText" parent="TextAppearance.Material3.DisplaySmall">
         <item name="android:fontFamily">serif</item>
         <item name="android:textColor">@color/textDark</item>
-        <item name="android:textSize">22sp</item>
+        <item name="android:textSize">24sp</item>
     </style>
     <style name="BodyText" parent="TextAppearance.Material3.BodyLarge">
-        <item name="android:textSize">16sp</item>
+        <item name="android:textSize">17sp</item>
         <item name="android:textColor">@color/textDark</item>
     </style>
     <!-- White text styles for image overlays -->
     <style name="BodyTextLight" parent="TextAppearance.Material3.BodyLarge">
-        <item name="android:textSize">16sp</item>
+        <item name="android:textSize">17sp</item>
         <item name="android:textColor">@android:color/white</item>
     </style>
     <style name="CaptionTextLight" parent="TextAppearance.Material3.BodySmall">
-        <item name="android:textSize">14sp</item>
+        <item name="android:textSize">15sp</item>
         <item name="android:textColor">@android:color/white</item>
     </style>
     <style name="CaptionText" parent="TextAppearance.Material3.BodySmall">
-        <item name="android:textSize">14sp</item>
+        <item name="android:textSize">15sp</item>
         <item name="android:textColor">@color/textDark</item>
         <item name="android:textStyle">italic</item>
     </style>


### PR DESCRIPTION
## Summary
- tune heading, body and caption text sizes
- adjust standard image dimensions and grid padding
- color artist and painting links using the accent color
- tint bottom nav icons and text using new selector
- update vector icons to allow tinting

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6acb34b4832ebcf906f3b0a63aee