### PR TITLE
Match iOS styling for related paintings

### DIFF
--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -8,7 +8,7 @@
 
     <ImageView
         android:id="@+id/paintingImage"
-        android:layout_width="120dp"
+        android:layout_width="@dimen/image_min_height_small"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
@@ -21,5 +21,5 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:gravity="center"
-        android:textAppearance="@style/PaintingTitleText" />
+        android:textAppearance="@style/PaintingTitleTextSmall" />
 </LinearLayout>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -27,6 +27,12 @@
         <item name="android:textColor">@color/textDark</item>
         <item name="android:textSize">24sp</item>
     </style>
+    <!-- Slightly smaller serif title used for horizontal lists -->
+    <style name="PaintingTitleTextSmall" parent="TextAppearance.Material3.TitleMedium">
+        <item name="android:fontFamily">serif</item>
+        <item name="android:textColor">@color/textDark</item>
+        <item name="android:textSize">18sp</item>
+    </style>
     <style name="BodyText" parent="TextAppearance.Material3.BodyLarge">
         <item name="android:textSize">17sp</item>
         <item name="android:textColor">@color/textDark</item>


### PR DESCRIPTION
## Summary
- add a smaller `PaintingTitleTextSmall` text style
- tweak related painting item layout to use square images and smaller text

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6c8c9108832e842aa59180123bb0