### PR TITLE
Update Android category UI

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -5,8 +5,8 @@ import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.Spinner
+import com.wikiart.CategorySpinnerAdapter
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -42,8 +42,8 @@ class ArtistsActivity : AppCompatActivity() {
 
         val spinner: Spinner = findViewById(R.id.artistCategorySpinner)
         val categories = ArtistCategory.values()
-        val categoryNames = resources.getStringArray(R.array.artist_category_names)
-        spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, categoryNames)
+        val spinnerAdapter = CategorySpinnerAdapter(this, categories)
+        spinner.adapter = spinnerAdapter
         spinner.setSelection(categories.indexOf(ArtistCategory.POPULAR))
 
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {

--- a/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
@@ -7,8 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.Spinner
+import com.wikiart.CategorySpinnerAdapter
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
@@ -68,8 +68,8 @@ class ArtistsFragment : Fragment() {
 
         val spinner: Spinner = view.findViewById(R.id.artistCategorySpinner)
         val categories = ArtistCategory.values()
-        val categoryNames = resources.getStringArray(R.array.artist_category_names)
-        spinner.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_dropdown_item, categoryNames)
+        val spinnerAdapter = CategorySpinnerAdapter(requireContext(), categories)
+        spinner.adapter = spinnerAdapter
         spinner.setSelection(categories.indexOf(ArtistCategory.POPULAR))
 
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {

--- a/android/app/src/main/java/com/wikiart/CategoryItem.kt
+++ b/android/app/src/main/java/com/wikiart/CategoryItem.kt
@@ -1,0 +1,6 @@
+package com.wikiart
+
+interface CategoryItem {
+    fun nameRes(): Int
+    fun iconRes(): Int
+}

--- a/android/app/src/main/java/com/wikiart/CategorySpinnerAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/CategorySpinnerAdapter.kt
@@ -1,0 +1,36 @@
+package com.wikiart
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ImageView
+import android.widget.TextView
+
+class CategorySpinnerAdapter<T : CategoryItem>(
+    context: Context,
+    private val categories: Array<T>
+) : ArrayAdapter<T>(context, R.layout.spinner_category_item, categories) {
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context)
+            .inflate(R.layout.spinner_category_item, parent, false)
+        bind(view, categories[position])
+        return view
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context)
+            .inflate(R.layout.spinner_category_item, parent, false)
+        bind(view, categories[position])
+        return view
+    }
+
+    private fun bind(view: View, category: T) {
+        val text = view.findViewById<TextView>(android.R.id.text1)
+        val icon = view.findViewById<ImageView>(R.id.iconView)
+        text.text = context.getString(category.nameRes())
+        icon.setImageResource(category.iconRes())
+    }
+}

--- a/android/app/src/main/java/com/wikiart/PaintingCategory.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingCategory.kt
@@ -1,6 +1,8 @@
 package com.wikiart
 
-enum class PaintingCategory {
+import com.wikiart.R
+
+enum class PaintingCategory : CategoryItem {
     MEDIA,
     STYLE,
     GENRE,
@@ -22,5 +24,25 @@ enum class PaintingCategory {
         POPULAR -> "Popular"
         FEATURED -> "Featured"
         FAVORITES -> "Favorites"
+    }
+
+    fun nameRes(): Int = when (this) {
+        MEDIA -> R.string.painting_category_media
+        STYLE -> R.string.painting_category_style
+        GENRE -> R.string.painting_category_genre
+        HIGH_RES -> R.string.painting_category_high_res
+        POPULAR -> R.string.painting_category_popular
+        FEATURED -> R.string.painting_category_featured
+        FAVORITES -> R.string.painting_category_favorites
+    }
+
+    fun iconRes(): Int = when (this) {
+        MEDIA -> R.drawable.ic_painting_media
+        STYLE -> R.drawable.ic_painting_style
+        GENRE -> R.drawable.ic_painting_genre
+        HIGH_RES -> R.drawable.ic_painting_high_res
+        POPULAR -> R.drawable.ic_painting_popular
+        FEATURED -> R.drawable.ic_painting_featured
+        FAVORITES -> R.drawable.ic_favorite_filled
     }
 }

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -7,8 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.Spinner
+import com.wikiart.CategorySpinnerAdapter
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
@@ -91,9 +91,7 @@ class PaintingsFragment : Fragment() {
 
         val spinner: Spinner = view.findViewById(R.id.categorySpinner)
         val categories = PaintingCategory.values()
-        val categoryNames = resources.getStringArray(R.array.painting_category_names)
-        val spinnerAdapter = ArrayAdapter(requireContext(), R.layout.spinner_category_item, categoryNames)
-        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        val spinnerAdapter = CategorySpinnerAdapter(requireContext(), categories)
         spinner.adapter = spinnerAdapter
         spinner.setSelection(categories.indexOf(PaintingCategory.FEATURED))
 

--- a/android/app/src/main/java/com/wikiart/model/ArtistCategory.kt
+++ b/android/app/src/main/java/com/wikiart/model/ArtistCategory.kt
@@ -1,10 +1,13 @@
 package com.wikiart.model
 
+import com.wikiart.R
+import com.wikiart.CategoryItem
+
 /**
  * Categories for browsing artists.
  * Mirrors the iOS ArtistCategory enum.
  */
-enum class ArtistCategory(val path: String, private val hasSections: Boolean) {
+enum class ArtistCategory(val path: String, private val hasSections: Boolean) : CategoryItem {
     ALPHABETICAL("Alphabet", false),
     ART_MOVEMENT("artists-by-Art-Movement", true),
     SCHOOL("artists-by-painting-school", true),
@@ -34,4 +37,21 @@ enum class ArtistCategory(val path: String, private val hasSections: Boolean) {
         RECENT -> "Recent"
         INSTITUTIONS -> "Art Institution"
     }
+
+    fun nameRes(): Int = when (this) {
+        ALPHABETICAL -> R.string.artist_category_alphabet
+        ART_MOVEMENT -> R.string.artist_category_art_movement
+        SCHOOL -> R.string.artist_category_school
+        GENRE -> R.string.artist_category_genre
+        FIELD -> R.string.artist_category_field
+        NATION -> R.string.artist_category_nation
+        CENTURIES -> R.string.artist_category_century
+        CHRONOLOGY -> R.string.artist_category_chronology
+        POPULAR -> R.string.artist_category_popular
+        FEMALE -> R.string.artist_category_female
+        RECENT -> R.string.artist_category_recent
+        INSTITUTIONS -> R.string.artist_category_institution
+    }
+
+    fun iconRes(): Int = R.drawable.ic_artists
 }

--- a/android/app/src/main/res/drawable/ic_painting_featured.xml
+++ b/android/app/src/main/res/drawable/ic_painting_featured.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M12,2 L15.09,8.26 L22,9.27 L17,14.14 L18.18,21.02 L12,17.77 L5.82,21.02 L7,14.14 L2,9.27 L8.91,8.26 L12,2 Z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_painting_genre.xml
+++ b/android/app/src/main/res/drawable/ic_painting_genre.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M7 7h0.01"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_painting_high_res.xml
+++ b/android/app/src/main/res/drawable/ic_painting_high_res.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M15 3 L21 3 L21 9"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M9 21 L3 21 L3 15"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M21 3 L14 10"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M3 21 L10 14"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_painting_media.xml
+++ b/android/app/src/main/res/drawable/ic_painting_media.xml
@@ -1,0 +1,46 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M2 2h20v20H2z"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M7 2v20"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M17 2v20"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M2 12h20"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M2 7h5"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M2 17h5"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M17 17h5"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M17 7h5"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_painting_popular.xml
+++ b/android/app/src/main/res/drawable/ic_painting_popular.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M23 6 L13.5 15.5 L8.5 10.5 L1 18"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M17 6 L23 6 L23 12"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_painting_style.xml
+++ b/android/app/src/main/res/drawable/ic_painting_style.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M12 2 a10 10 0 1 0 0.01 0z"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M14.31 8 L20.05 17.94"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M9.69 8 L21.17 8"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M7.38 12 L13.12 2.06"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M9.69 16 L3.95 6.06"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M14.31 16 L2.83 16"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="?attr/colorControlNormal"
+        android:strokeWidth="2"
+        android:pathData="M16.62 12 L10.88 21.94"/>
+</vector>

--- a/android/app/src/main/res/layout/spinner_category_item.xml
+++ b/android/app/src/main/res/layout/spinner_category_item.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/text1"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center"
-    android:padding="8dp"
-    android:textAppearance="@style/HeadingText" />
+    android:gravity="center_vertical"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/iconView"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginEnd="8dp"
+        android:tint="?attr/colorControlNormal" />
+
+    <TextView
+        android:id="@android:id/text1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="@style/HeadingText" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add generic `CategorySpinnerAdapter`
- display icons and text in `spinner_category_item`
- map icons and names in `PaintingCategory` and `ArtistCategory`
- use `CategorySpinnerAdapter` in painting and artist views
- provide simple vector drawable icons

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d9b8e6c832eb2880f2b3fe453f3