### PR TITLE
Add layout chooser to search views

### DIFF
--- a/android/app/src/main/res/layout/activity_search.xml
+++ b/android/app/src/main/res/layout/activity_search.xml
@@ -2,14 +2,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/groupBackground">
 
-    <AutoCompleteTextView
-        android:id="@+id/searchInput"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/search"
-        android:textAppearance="@style/BodyText" />
+        android:orientation="horizontal">
+
+        <AutoCompleteTextView
+            android:id="@+id/searchInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/search"
+            android:textAppearance="@style/BodyText" />
+
+        <ImageButton
+            android:id="@+id/layoutButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/change_layout"
+            android:src="@drawable/ic_gallery"
+            android:background="?attr/selectableItemBackgroundBorderless" />
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/resultsRecyclerView"

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -2,14 +2,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/groupBackground">
 
-    <AutoCompleteTextView
-        android:id="@+id/searchInput"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/search"
-        android:textAppearance="@style/BodyText" />
+        android:orientation="horizontal">
+
+        <AutoCompleteTextView
+            android:id="@+id/searchInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/search"
+            android:textAppearance="@style/BodyText" />
+
+        <ImageButton
+            android:id="@+id/layoutButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/change_layout"
+            android:src="@drawable/ic_gallery"
+            android:background="?attr/selectableItemBackgroundBorderless" />
+    </LinearLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"


### PR DESCRIPTION
## Summary
- let SearchFragment load and save layout type
- implement popup to change layouts
- mirror same behavior in SearchActivity
- update search layouts with layout button and background

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b71177bc4832ea075e842656be292