### PR TITLE
Match iOS layouts in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ language with a fallback to English when needed.
 
 Paintings can be viewed in three layouts—list, grid and sheet—mirroring the
 iOS design. The list and grid layouts display the artist name, title and year
-beneath each image while the sheet layout shows only the artwork image.
+beneath each image while the sheet layout shows only the artwork image. The
+grid layout now uses a staggered grid so images keep their original aspect
+ratio just like on iOS.

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -50,10 +50,10 @@ class PaintingAdapter(
                 val padding = itemView.resources.getDimensionPixelSize(
                     R.dimen.painting_grid_image_padding
                 ) * 2
+                val width = itemWidth - padding
+                val ratio = painting.height.toFloat() / painting.width
                 paintingImage.layoutParams = paintingImage.layoutParams.apply {
-                    // use a fixed 1:1 ratio so all grid items occupy
-                    // the same rectangular area, accounting for padding
-                    height = itemWidth - padding
+                    height = (width * ratio).toInt()
                 }
             }
 

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -118,7 +118,7 @@ class PaintingsFragment : Fragment() {
     }
 
     private fun layoutManagerFor(type: LayoutType): RecyclerView.LayoutManager = when (type) {
-        LayoutType.COLUMN -> GridLayoutManager(requireContext(), 2)
+        LayoutType.COLUMN -> StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
         LayoutType.SHEET -> StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
         else -> LinearLayoutManager(requireContext())
     }


### PR DESCRIPTION
## Summary
- support variable painting aspect ratios in grid view
- switch grid layout manager to `StaggeredGridLayoutManager`
- document use of staggered grid in README

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7338a068832e9438b715f79c1068