### PR TITLE
Add disk cache to WikiArt service

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -24,7 +24,7 @@ class ArtistDetailActivity : AppCompatActivity() {
 
     private var bioExpanded = false
 
-    private val repository = PaintingRepository()
+    private val repository = PaintingRepository(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
@@ -35,7 +35,7 @@ class ArtistPaintingsActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository = PaintingRepository(this)
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
     private var pagingJob: Job? = null
 

--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -28,7 +28,7 @@ class ArtistsActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository = PaintingRepository(this)
     private var pagingJob: Job? = null
     private var currentSection: String? = null
 

--- a/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
@@ -32,7 +32,7 @@ class ArtistsFragment : Fragment() {
         requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository by lazy { PaintingRepository(requireContext()) }
     private var pagingJob: Job? = null
     private var currentSection: String? = null
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 
 class PaintingDetailActivity : AppCompatActivity() {
 
-    private val repository = PaintingRepository()
+    private val repository = PaintingRepository(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -11,7 +11,12 @@ import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
 import com.wikiart.model.ArtistSection
 
-class PaintingRepository(private val service: WikiArtService = WikiArtService()) {
+import android.content.Context
+
+class PaintingRepository(
+    context: Context? = null,
+    private val service: WikiArtService = WikiArtService(cacheDir = context?.cacheDir)
+) {
 
     private val pageSize = 20
     private val prefetchDistance = 5

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -44,7 +44,7 @@ class PaintingsFragment : Fragment() {
         requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository by lazy { PaintingRepository(requireContext()) }
     private var pagingJob: Job? = null
     private var currentSectionId: String? = null
 

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -35,7 +35,7 @@ class SearchActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository = PaintingRepository(this)
     private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -41,7 +41,7 @@ class SearchFragment : Fragment() {
         requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository()
+    private val repository by lazy { PaintingRepository(requireContext()) }
     private var searchJob: Job? = null
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -1,9 +1,11 @@
 package com.wikiart
 
 import com.google.gson.Gson
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
+import java.io.File
 import android.util.Log
 import com.wikiart.BuildConfig
 import com.wikiart.model.PaintingSection
@@ -15,11 +17,12 @@ import com.wikiart.model.ArtistsList
 
 class WikiArtService(
     private val serverConfig: ServerConfigType = ServerConfig.production,
-    private val language: String = java.util.Locale.getDefault().language
+    private val language: String = java.util.Locale.getDefault().language,
+    cacheDir: File? = null
 ) {
     companion object {
-        private val sharedClient: OkHttpClient by lazy {
-            OkHttpClient.Builder()
+        private fun buildClient(cacheDir: File?): OkHttpClient {
+            val builder = OkHttpClient.Builder()
                 .addInterceptor(HttpLoggingInterceptor().apply {
                     level = if (BuildConfig.DEBUG) {
                         HttpLoggingInterceptor.Level.BODY
@@ -27,11 +30,14 @@ class WikiArtService(
                         HttpLoggingInterceptor.Level.NONE
                     }
                 })
-                .build()
+            cacheDir?.let {
+                builder.cache(Cache(File(it, "http_cache"), 10L * 1024 * 1024))
+            }
+            return builder.build()
         }
     }
 
-    private val client = sharedClient
+    private val client = buildClient(cacheDir)
     private val gson = Gson()
     private val TAG = "WikiArtService"
 


### PR DESCRIPTION
## Summary
- add OkHttp `Cache` to `WikiArtService`
- allow `PaintingRepository` to inject `Context` so cached client is used
- pass `Context` from activities and fragments when creating repositories

## Testing
- `./android/gradlew -p android test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b73785df4832e8d9e4b39c14f2416