### PR TITLE
Fix SearchActivity View imports

### DIFF
--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -8,6 +8,7 @@ import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import android.text.TextWatcher
 import android.text.Editable
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -44,7 +45,7 @@ class SearchActivity : AppCompatActivity() {
 
         val input: AutoCompleteTextView = findViewById(R.id.searchInput)
         recyclerView = findViewById(R.id.resultsRecyclerView)
-        layoutButton = findViewById(R.id.layoutButton)
+        layoutButton = findViewById<View>(R.id.layoutButton)
 
         val prefs = getSharedPreferences("prefs", Context.MODE_PRIVATE)
         val name = prefs.getString("layout_type", LayoutType.COLUMN.name) ?: LayoutType.COLUMN.name
@@ -53,7 +54,9 @@ class SearchActivity : AppCompatActivity() {
         recyclerView.layoutManager = layoutManagerFor(layoutType)
         adapter.layoutType = layoutType
         recyclerView.adapter = adapter
-        layoutButton.setOnClickListener { showLayoutMenu(it) }
+        layoutButton.setOnClickListener { view ->
+            showLayoutMenu(view)
+        }
 
         val suggestions = ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line)
         input.setAdapter(suggestions)


### PR DESCRIPTION
## Summary
- import android.view.View in SearchActivity
- specify view type when resolving layoutButton
- use explicit lambda variable when invoking showLayoutMenu

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b73ef94c4832eb5e4d3922ce750d8