### PR TITLE
Add translucent detail overlay theme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,13 +15,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".PaintingDetailActivity" />
+        <activity
+            android:name=".PaintingDetailActivity"
+            android:theme="@style/TranslucentDetailTheme" />
         <activity android:name=".SearchActivity" />
         <activity android:name=".StoreActivity" />
         <activity
             android:name=".ImageDetailActivity"
             android:theme="@style/FullScreenTheme" />
-        <activity android:name=".ArtistDetailActivity" />
+        <activity
+            android:name=".ArtistDetailActivity"
+            android:theme="@style/TranslucentDetailTheme" />
         <activity android:name=".ArtistsActivity" />
         <activity android:name=".ArtistPaintingsActivity" />
 

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -2,7 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/groupBackground">
+    android:background="@color/groupBackgroundTranslucent">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:transitionName="paintingDetail"
-    android:background="@color/groupBackground">
+    android:background="@color/groupBackgroundTranslucent">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -7,6 +7,8 @@
     <color name="textLight">#888888</color>
     <!-- Backgrounds matching iOS list appearance -->
     <color name="groupBackground">#F2F2F7</color>
+    <!-- Semi transparent background for modal details -->
+    <color name="groupBackgroundTranslucent">#CCF2F2F7</color>
     <color name="cardBackground">#FFFFFF</color>
     <color name="imagePlaceholder">#C6C6C8</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -52,6 +52,13 @@
         <item name="android:textStyle">italic</item>
     </style>
 
+    <!-- Theme for translucent detail overlays -->
+    <style name="TranslucentDetailTheme" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
     <style name="TextAppearance.BodyLarge" parent="TextAppearance.Material3.BodyLarge" />
 
 </resources>


### PR DESCRIPTION
## Summary
- enable translucent backgrounds for painting and artist detail screens
- add new `TranslucentDetailTheme`
- use new theme for detail activities
- fade detail backgrounds

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b75371234832eb85298578582de3c