### PR TITLE
Fix crash on activity launch due to early repository init

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -24,7 +24,7 @@ class ArtistDetailActivity : AppCompatActivity() {
 
     private var bioExpanded = false
 
-    private val repository = PaintingRepository(this)
+    private val repository by lazy { PaintingRepository(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
@@ -35,7 +35,7 @@ class ArtistPaintingsActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository(this)
+    private val repository by lazy { PaintingRepository(this) }
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
     private var pagingJob: Job? = null
 

--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -28,7 +28,7 @@ class ArtistsActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository(this)
+    private val repository by lazy { PaintingRepository(this) }
     private var pagingJob: Job? = null
     private var currentSection: String? = null
 

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 
 class PaintingDetailActivity : AppCompatActivity() {
 
-    private val repository = PaintingRepository(this)
+    private val repository by lazy { PaintingRepository(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -36,7 +36,7 @@ class SearchActivity : AppCompatActivity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
-    private val repository = PaintingRepository(this)
+    private val repository by lazy { PaintingRepository(this) }
     private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- avoid initializing `PaintingRepository` before `Activity` attaches to a base context

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b75a66400832e80f07c0bde8747e3