### PR TITLE
Fix repository init in tests

### DIFF
--- a/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
+++ b/android/app/src/test/java/com/wikiart/PaintingRepositoryTest.kt
@@ -14,7 +14,7 @@ class PaintingRepositoryTest {
     @Test
     fun pagingFlowCreatesWikiArtPagingSource() {
         val service = mockk<WikiArtService>(relaxed = true)
-        val repo = PaintingRepository(service)
+        val repo = PaintingRepository(service = service)
         val flow = repo.pagingFlow(PaintingCategory.FEATURED, "section")
 
         val field = flow.javaClass.getDeclaredField("this$0")
@@ -36,7 +36,7 @@ class PaintingRepositoryTest {
     @Test
     fun artistPaintingsPagingFlowCreatesSource() {
         val service = mockk<WikiArtService>(relaxed = true)
-        val repo = PaintingRepository(service)
+        val repo = PaintingRepository(service = service)
         val flow = repo.artistPaintingsPagingFlow("/foo", ArtistPaintingSort.DATE)
 
         val field = flow.javaClass.getDeclaredField("this$0")


### PR DESCRIPTION
## Summary
- update `PaintingRepositoryTest` to pass `service` by name

## Testing
- `./gradlew test` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b76c5e610832e8808fa0983664eb0