### PR TITLE
Add shared element transition for painting list

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -14,12 +14,15 @@ import kotlinx.coroutines.launch
 import android.view.View
 
 class ArtistDetailActivity : AppCompatActivity() {
-    private val adapter = RelatedPaintingAdapter { painting ->
+    private val adapter = RelatedPaintingAdapter { painting, image ->
         val intent = android.content.Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            this,
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private var bioExpanded = false

--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsActivity.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.cachedIn
 import android.widget.ArrayAdapter
 import android.widget.Spinner
+import android.widget.ImageView
 import android.view.Menu
 import android.view.MenuItem
 import android.content.Context
@@ -27,12 +28,15 @@ import kotlinx.coroutines.launch
 class ArtistPaintingsActivity : AppCompatActivity() {
     private var layoutType: LayoutType = LayoutType.SHEET
     private var sort: ArtistPaintingSort = ArtistPaintingSort.DATE
-    private val adapter = PaintingAdapter(layoutType) { painting ->
+    private val adapter = PaintingAdapter(layoutType) { painting, image ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            this,
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository by lazy { PaintingRepository(this) }

--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -10,17 +10,21 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.paging.PagingData
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.paging.LoadState
+import android.widget.ImageView
 import com.wikiart.data.FavoritesRepository
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class FavoritesActivity : AppCompatActivity() {
-    private val adapter = PaintingAdapter { painting ->
+    private val adapter = PaintingAdapter { painting, image ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            this,
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 

--- a/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.PagingData
@@ -17,12 +18,15 @@ import com.wikiart.data.FavoritesRepository
 import kotlinx.coroutines.launch
 
 class FavoritesFragment : Fragment() {
-    private val adapter = PaintingAdapter { painting ->
+    private val adapter = PaintingAdapter { painting, image ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            requireActivity(),
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -13,7 +13,7 @@ import com.wikiart.model.LayoutType
 
 class PaintingAdapter(
     var layoutType: LayoutType = LayoutType.LIST,
-    private val onItemClick: (Painting) -> Unit = {}
+    private val onItemClick: (Painting, ImageView) -> Unit = { _, _ -> }
 ) : PagingDataAdapter<Painting, PaintingAdapter.PaintingViewHolder>(DIFF_CALLBACK) {
 
     override fun getItemViewType(position: Int): Int = layoutType.ordinal
@@ -59,7 +59,7 @@ class PaintingAdapter(
 
             paintingImage.load(painting.thumbUrl)
 
-            itemView.setOnClickListener { onItemClick(painting) }
+            itemView.setOnClickListener { onItemClick(painting, paintingImage) }
         }
     }
 

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -10,6 +10,10 @@ import android.widget.ImageButton
 import android.widget.Toast
 import android.view.View
 import android.app.ActivityOptions
+import android.graphics.Color
+import android.view.Window
+import com.google.android.material.transition.platform.MaterialContainerTransform
+import com.google.android.material.transition.platform.MaterialContainerTransformSharedElementCallback
 import com.wikiart.ImageDetailActivity
 import coil.load
 import androidx.lifecycle.lifecycleScope
@@ -23,8 +27,21 @@ class PaintingDetailActivity : AppCompatActivity() {
     private val repository by lazy { PaintingRepository(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        window.requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
+        setEnterSharedElementCallback(MaterialContainerTransformSharedElementCallback())
+        setExitSharedElementCallback(MaterialContainerTransformSharedElementCallback())
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_painting_detail)
+        window.sharedElementEnterTransition = MaterialContainerTransform().apply {
+            addTarget(android.R.id.content)
+            duration = 300
+            scrimColor = Color.TRANSPARENT
+        }
+        window.sharedElementReturnTransition = MaterialContainerTransform().apply {
+            addTarget(android.R.id.content)
+            duration = 300
+            scrimColor = Color.TRANSPARENT
+        }
 
         val painting = intent.getSerializableExtra(EXTRA_PAINTING) as? Painting
 
@@ -140,12 +157,15 @@ class PaintingDetailActivity : AppCompatActivity() {
 
         val relatedRecycler: RecyclerView = findViewById(R.id.relatedRecyclerView)
         val relatedTitle: TextView = findViewById(R.id.relatedTitle)
-        val relatedAdapter = RelatedPaintingAdapter { selected ->
+        val relatedAdapter = RelatedPaintingAdapter { selected, image ->
             val intent = Intent(this, PaintingDetailActivity::class.java)
             intent.putExtra(EXTRA_PAINTING, selected)
-            val options = ActivityOptions.makeSceneTransitionAnimation(this)
+            val options = ActivityOptions.makeSceneTransitionAnimation(
+                this,
+                image,
+                image.transitionName
+            )
             startActivity(intent, options.toBundle())
-            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         }
         relatedRecycler.layoutManager = LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
         relatedRecycler.adapter = relatedAdapter

--- a/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.Spinner
+import android.widget.ImageView
 import com.wikiart.CategorySpinnerAdapter
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -36,12 +37,15 @@ class PaintingsFragment : Fragment() {
     private lateinit var layoutButton: View
     private var layoutType: LayoutType = LayoutType.COLUMN
 
-    private val itemClick: (Painting) -> Unit = { painting ->
+    private val itemClick: (Painting, ImageView) -> Unit = { painting, image ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            requireActivity(),
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository by lazy { PaintingRepository(requireContext()) }

--- a/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 
 class RelatedPaintingAdapter(
-    private val onItemClick: (Painting) -> Unit = {}
+    private val onItemClick: (Painting, ImageView) -> Unit = { _, _ -> }
 ) : androidx.recyclerview.widget.ListAdapter<Painting, RelatedPaintingAdapter.ViewHolder>(Diff()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -29,7 +29,7 @@ class RelatedPaintingAdapter(
         fun bind(painting: Painting) {
             title.text = painting.title
             image.load(painting.thumbUrl)
-            itemView.setOnClickListener { onItemClick(painting) }
+            itemView.setOnClickListener { onItemClick(painting, image) }
         }
     }
 

--- a/android/app/src/main/java/com/wikiart/SearchActivity.kt
+++ b/android/app/src/main/java/com/wikiart/SearchActivity.kt
@@ -6,6 +6,7 @@ import android.app.ActivityOptions
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
+import android.widget.ImageView
 import android.text.TextWatcher
 import android.text.Editable
 import android.view.View
@@ -27,13 +28,16 @@ class SearchActivity : AppCompatActivity() {
     private var layoutType: LayoutType = LayoutType.COLUMN
     private lateinit var layoutButton: View
     private lateinit var recyclerView: RecyclerView
-    private val adapter = PaintingAdapter(layoutType) { painting ->
+    private val adapter = PaintingAdapter(layoutType) { painting, image ->
         val intent = Intent(this, PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
         intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.detailUrl)
-        val options = ActivityOptions.makeSceneTransitionAnimation(this)
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            this,
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository by lazy { PaintingRepository(this) }

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
+import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.cachedIn
@@ -32,13 +33,16 @@ class SearchFragment : Fragment() {
     private var layoutType: LayoutType = LayoutType.COLUMN
     private lateinit var layoutButton: View
     private lateinit var recyclerView: RecyclerView
-    private val adapter = PaintingAdapter(layoutType) { painting ->
+    private val adapter = PaintingAdapter(layoutType) { painting, image ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
         intent.putExtra(PaintingDetailActivity.EXTRA_TITLE, painting.title)
         intent.putExtra(PaintingDetailActivity.EXTRA_IMAGE, painting.detailUrl)
-        val options = ActivityOptions.makeSceneTransitionAnimation(requireActivity())
+        val options = ActivityOptions.makeSceneTransitionAnimation(
+            requireActivity(),
+            image,
+            image.transitionName
+        )
         startActivity(intent, options.toBundle())
-        requireActivity().overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private val repository by lazy { PaintingRepository(requireContext()) }

--- a/android/app/src/main/res/layout/item_painting_grid.xml
+++ b/android/app/src/main/res/layout/item_painting_grid.xml
@@ -15,7 +15,8 @@
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
         android:minHeight="@dimen/image_min_height_small"
-        android:background="@color/imagePlaceholder" />
+        android:background="@color/imagePlaceholder"
+        android:transitionName="@string/transition_detail_image" />
 
     <TextView
         android:id="@+id/artistText"

--- a/android/app/src/main/res/layout/item_painting_sheet.xml
+++ b/android/app/src/main/res/layout/item_painting_sheet.xml
@@ -13,7 +13,8 @@
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
         android:minHeight="@dimen/image_min_height_standard"
-        android:background="@color/imagePlaceholder" />
+        android:background="@color/imagePlaceholder"
+        android:transitionName="@string/transition_detail_image" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -13,7 +13,8 @@
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
         android:minHeight="@dimen/image_min_height_small"
-        android:background="@color/imagePlaceholder" />
+        android:background="@color/imagePlaceholder"
+        android:transitionName="@string/transition_detail_image" />
 
     <TextView
         android:id="@+id/titleText"

--- a/android/app/src/main/res/layout/list_item_painting.xml
+++ b/android/app/src/main/res/layout/list_item_painting.xml
@@ -13,7 +13,8 @@
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
         android:minHeight="@dimen/image_min_height_standard"
-        android:background="@color/imagePlaceholder" />
+        android:background="@color/imagePlaceholder"
+        android:transitionName="@string/transition_detail_image" />
 
     <TextView
         android:id="@+id/artistText"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="died">Died: %1$s</string>
     <string name="change_layout">Change layout</string>
 
+    <!-- Transition name used for shared element animations -->
+    <string name="transition_detail_image">detailImage</string>
+
     <string-array name="painting_category_names">
         <item>@string/painting_category_favorites</item>
         <item>@string/painting_category_featured</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorSecondary">@color/colorSecondary</item>
         <item name="textAppearanceBodyLarge">@style/TextAppearance.BodyLarge</item>
+        <item name="android:windowContentTransitions">true</item>
     </style>
 
     <!-- Full screen theme without an action bar. -->
@@ -57,6 +58,7 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowContentTransitions">true</item>
     </style>
 
     <style name="TextAppearance.BodyLarge" parent="TextAppearance.Material3.BodyLarge" />


### PR DESCRIPTION
## Summary
- add window transition support in themes
- pass the clicked image view to list item callbacks
- launch `PaintingDetailActivity` with a shared element
- animate painting detail screen with `MaterialContainerTransform`
- assign transition names for painting images
- expose string resource for the shared element name

## Testing
- `sh gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b77451f78832e9dde62e303dee6a3