### PR TITLE
Fix related paintings layout

### DIFF
--- a/android/app/src/main/res/layout/item_related_painting.xml
+++ b/android/app/src/main/res/layout/item_related_painting.xml
@@ -8,11 +8,10 @@
 
     <ImageView
         android:id="@+id/paintingImage"
-        android:layout_width="@dimen/image_min_height_small"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/related_painting_image_height"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:minHeight="@dimen/image_min_height_small"
         android:background="@color/imagePlaceholder"
         android:transitionName="@string/transition_detail_image" />
 

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -8,4 +8,6 @@
     <dimen name="painting_grid_image_padding">16dp</dimen>
     <!-- Blur radius applied to translucent detail overlays -->
     <dimen name="detail_blur_radius">30dp</dimen>
+    <!-- Height for paintings in the horizontal list on the detail screen -->
+    <dimen name="related_painting_image_height">240dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- change related painting row to match iOS size
- use new dimension for related painting height

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b79b58138832eb8db8e062729f790