### PR TITLE
Fix crash with decor view blur

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -32,12 +32,12 @@ class ArtistDetailActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_artist_detail)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(
                 resources.getDimensionPixelSize(R.dimen.detail_blur_radius)
             )
         }
-        setContentView(R.layout.activity_artist_detail)
 
         val recycler: RecyclerView = findViewById(R.id.famousRecyclerView)
         recycler.layoutManager = LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)

--- a/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
@@ -12,12 +12,12 @@ import com.github.chrisbanes.photoview.PhotoView
 class ImageDetailActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_image_detail)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(
                 resources.getDimensionPixelSize(R.dimen.detail_blur_radius)
             )
         }
-        setContentView(R.layout.activity_image_detail)
 
         enterImmersiveMode()
 

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -32,12 +32,12 @@ class PaintingDetailActivity : AppCompatActivity() {
         setEnterSharedElementCallback(MaterialContainerTransformSharedElementCallback())
         setExitSharedElementCallback(MaterialContainerTransformSharedElementCallback())
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_painting_detail)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(
                 resources.getDimensionPixelSize(R.dimen.detail_blur_radius)
             )
         }
-        setContentView(R.layout.activity_painting_detail)
         window.sharedElementEnterTransition = MaterialContainerTransform().apply {
             addTarget(android.R.id.content)
             duration = 300


### PR DESCRIPTION
## Summary
- set the content view before applying blur radius for window background
  - in ArtistDetailActivity, ImageDetailActivity, and PaintingDetailActivity
- prevents `NullPointerException` when decor view is not ready

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7a43f8b0832ebcb9db320284848c