### PR TITLE
Remove margins on painting rows

### DIFF
--- a/WikiArt3.0/Cells/Collection/PaintingCollectionViewCell.xib
+++ b/WikiArt3.0/Cells/Collection/PaintingCollectionViewCell.xib
@@ -46,7 +46,7 @@
                     </imageView>
                 </subviews>
             </view>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="X7X-vm-fgi" secondAttribute="trailing" id="5rO-RC-5LA"/>
                 <constraint firstItem="X7X-vm-fgi" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="IQn-0A-byK"/>

--- a/WikiArt3.0/Services/LayoutService.swift
+++ b/WikiArt3.0/Services/LayoutService.swift
@@ -58,7 +58,7 @@ struct PadLayoutService: LayoutService {
         let layout = RowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumInteritemSpacing = 4
-        layout.sectionInset = .init(top: 0, left: 20, bottom: 0, right: 20)
+        layout.sectionInset = .zero
         return layout
     }
 }
@@ -83,7 +83,7 @@ struct PhoneLayoutService: LayoutService {
     func paintingRowFlow() -> UICollectionViewLayout {
         let layout = RowLayout()
         layout.scrollDirection = .horizontal
-        layout.sectionInset = .init(top: 0, left: 20, bottom: 0, right: 20)
+        layout.sectionInset = .zero
         return layout
     }
 }


### PR DESCRIPTION
## Summary
- make horizontal spacing for related/famous paintings zero
- clear painting cell background so row is transparent

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7c15136c832ea9d1200fc5313ab5