### PR TITLE
Fix favorites DB calls on background thread

### DIFF
--- a/android/app/src/main/java/com/wikiart/data/FavoritesRepository.kt
+++ b/android/app/src/main/java/com/wikiart/data/FavoritesRepository.kt
@@ -2,16 +2,20 @@ package com.wikiart.data
 
 import android.content.Context
 import com.wikiart.Painting
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 class FavoritesRepository(context: Context) {
     private val dao = FavoritesDatabase.getDatabase(context).favoritesDao()
 
-    fun favoritesFlow(): Flow<List<Painting>> = dao.favoritesFlow()
+    fun favoritesFlow(): Flow<List<Painting>> =
+        dao.favoritesFlow().flowOn(Dispatchers.IO)
 
-    suspend fun isFavorite(id: String): Boolean = dao.isFavorite(id)
+    suspend fun isFavorite(id: String): Boolean = withContext(Dispatchers.IO) {
+        dao.isFavorite(id)
+    }
 
     suspend fun addFavorite(painting: Painting) = withContext(Dispatchers.IO) {
         dao.insert(painting)


### PR DESCRIPTION
## Summary
- ensure favorite database queries run on `Dispatchers.IO`
- emit favorites flow on `Dispatchers.IO`

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7c40671c832eb30d1e11926edbc1