### PR TITLE
Fix initial painting list not loading

### DIFF
--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -48,6 +48,10 @@ class MainActivity : AppCompatActivity() {
             }
 
         }
+        // Display the Paintings fragment on launch
+        if (savedInstanceState == null) {
+            nav.selectedItemId = R.id.nav_paintings
+        }
     }
 
     private fun switchFragment(fragment: Fragment) {


### PR DESCRIPTION
## Summary
- ensure the bottom navigation selects the `Paintings` tab on startup so images load immediately

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7de87e90832eb9d8405b0cf12146