### PR TITLE
Fix blur radius call in PaintingDetailActivity

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -34,7 +34,7 @@ class PaintingDetailActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_painting_detail)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            window.decorView.setBackgroundBlurRadius(
+            window.setBackgroundBlurRadius(
                 resources.getDimensionPixelSize(R.dimen.detail_blur_radius)
             )
         }


### PR DESCRIPTION
## Summary
- fix `setBackgroundBlurRadius` call for Android 12+

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7ee37820832eb835dbc6d26f1111