### PR TITLE
Improve Android port docs and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # WikiArt Mobile
 
 This repository originally contained both an iOS project and an Android port.
-The iOS project has been removed, leaving only the Android source code.
+The Android app is actively maintained while the iOS sources remain for
+reference.
 
 * `android` – Android application written in Kotlin.
 
@@ -22,3 +23,12 @@ iOS design. The list and grid layouts display the artist name, title and year
 beneath each image while the sheet layout shows only the artwork image. The
 grid layout now uses a staggered grid so images keep their original aspect
 ratio just like on iOS.
+
+The latest update adds Material You dynamic color support on Android 12+
+devices, automatically adapting the app theme to the user's wallpaper.
+
+## Future improvements
+
+- Cache paintings for offline viewing
+- Port additional iOS features such as artwork collections
+- Explore a Jetpack Compose UI rewrite

--- a/android/README.md
+++ b/android/README.md
@@ -13,6 +13,8 @@ full screen and visit a Support screen to send feedback or make a donation using
 Google Play Billing. The bottom navigation bar handles switching between the
 Paintings, Artists, Search and Support fragments, replacing the old options
 menu.
+Material You dynamic colors are applied on Android 12 and above so the app theme
+matches your wallpaper.
 Section titles in category dialogs are shown in your device language when
 available, defaulting to English otherwise.
 
@@ -45,3 +47,9 @@ KITE_PUBLIC_KEY=<kite public key>
 Values from `local.properties` take precedence, falling back to the environment
 when not present. If the API endpoint values are blank the app defaults to
 `www.wikiart.org`.
+
+## Future work
+
+- Cache API responses locally to allow browsing offline
+- Add push notifications for featured paintings
+- Consider migrating views to Jetpack Compose

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:name=".WikiArtApplication"
         android:label="WikiArt"
         android:allowBackup="true"
         android:supportsRtl="true"

--- a/android/app/src/main/java/com/wikiart/WikiArtApplication.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtApplication.kt
@@ -1,0 +1,11 @@
+package com.wikiart
+
+import android.app.Application
+import com.google.android.material.color.DynamicColors
+
+class WikiArtApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        DynamicColors.applyToActivitiesIfAvailable(this)
+    }
+}


### PR DESCRIPTION
## Summary
- document new dynamic color support and future plans
- update Android documentation to mention dynamic color
- add WikiArtApplication to apply Material You colors
- hook application class up in the manifest

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b81bd21f0832ebee088fd43fa42ca