### PR TITLE
Add painting details screen parity

### DIFF
--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -8,6 +8,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Button
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.Toast
 import android.view.View
 import android.app.ActivityOptions
@@ -178,6 +179,12 @@ class PaintingDetailActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             painting?.let {
+                val detailsContainer: LinearLayout = findViewById(R.id.detailsContainer)
+                val details = repository.getPaintingDetails(it.id)
+                details?.let { d ->
+                    addDetails(detailsContainer, d)
+                    detailsContainer.visibility = View.VISIBLE
+                }
                 val related = repository.getRelatedPaintings(it.paintingUrl)
                 if (related.isNotEmpty()) {
                     relatedAdapter.submitList(related)
@@ -188,6 +195,43 @@ class PaintingDetailActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun addDetails(container: LinearLayout, details: PaintingDetails) {
+        details.location?.takeIf { it.isNotBlank() }?.let {
+            addDetail(container, getString(R.string.location_label), it)
+        }
+        details.period?.takeIf { it.isNotBlank() }?.let {
+            addDetail(container, getString(R.string.period_label), it)
+        }
+        details.series?.takeIf { it.isNotBlank() }?.let {
+            addDetail(container, getString(R.string.series_label), it)
+        }
+        details.genres?.takeIf { it.isNotEmpty() }?.let {
+            addDetail(container, getString(R.string.genres_label), it.joinToString(", "))
+        }
+        details.styles?.takeIf { it.isNotEmpty() }?.let {
+            addDetail(container, getString(R.string.styles_label), it.joinToString(", "))
+        }
+        details.media?.takeIf { it.isNotEmpty() }?.let {
+            addDetail(container, getString(R.string.media_label), it.joinToString(", "))
+        }
+        details.galleries?.takeIf { it.isNotEmpty() }?.let {
+            addDetail(container, getString(R.string.galleries_label), it.joinToString(", "))
+        }
+        details.tags?.takeIf { it.isNotEmpty() }?.let {
+            addDetail(container, getString(R.string.tags_label), it.joinToString(", "))
+        }
+        details.description?.takeIf { it.isNotBlank() }?.let {
+            addDetail(container, getString(R.string.description_label), it)
+        }
+    }
+
+    private fun addDetail(container: LinearLayout, label: String, value: String) {
+        val view = layoutInflater.inflate(R.layout.item_painting_detail_field, container, false)
+        view.findViewById<TextView>(R.id.detailLabel).text = label
+        view.findViewById<TextView>(R.id.detailValue).text = value
+        container.addView(view)
     }
 
     companion object {

--- a/android/app/src/main/java/com/wikiart/PaintingDetails.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetails.kt
@@ -1,0 +1,33 @@
+package com.wikiart
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+/**
+ * Detailed painting information returned from the API.
+ */
+data class PaintingDetails(
+    @SerializedName("id") val id: String?,
+    @SerializedName("title") val title: String?,
+    @SerializedName("url") val url: String?,
+    @SerializedName("artistUrl") val artistUrl: String?,
+    @SerializedName("artistName") val artistName: String?,
+    @SerializedName("artistId") val artistId: String?,
+    @SerializedName("completitionYear") val completionYear: Int?,
+    @SerializedName("dictionaries") val dictionaries: List<String>?,
+    @SerializedName("location") val location: String?,
+    @SerializedName("period") val period: String?,
+    @SerializedName("serie") val series: String?,
+    @SerializedName("genres") val genres: List<String>?,
+    @SerializedName("styles") val styles: List<String>?,
+    @SerializedName("media") val media: List<String>?,
+    @SerializedName("sizeX") val sizeX: Float?,
+    @SerializedName("sizeY") val sizeY: Float?,
+    @SerializedName("diameter") val diameter: Double?,
+    @SerializedName("galleries") val galleries: List<String>?,
+    @SerializedName("tags") val tags: List<String>?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("width") val width: Int?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("height") val height: Int?
+) : Serializable

--- a/android/app/src/main/java/com/wikiart/PaintingRepository.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingRepository.kt
@@ -55,6 +55,11 @@ class PaintingRepository(
         withContext(Dispatchers.IO) {
             service.fetchRelatedPaintings(path)?.paintings ?: emptyList()
         }
+
+    suspend fun getPaintingDetails(id: String): PaintingDetails? =
+        withContext(Dispatchers.IO) {
+            service.fetchPaintingDetails(id)
+        }
     suspend fun sections(category: PaintingCategory): List<PaintingSection> =
         withContext(Dispatchers.IO) {
             service.fetchSections(category) ?: emptyList()

--- a/android/app/src/main/java/com/wikiart/WikiArtService.kt
+++ b/android/app/src/main/java/com/wikiart/WikiArtService.kt
@@ -120,6 +120,19 @@ class WikiArtService(
             return result
         }
     }
+
+    fun fetchPaintingDetails(id: String): PaintingDetails? {
+        val url = "${serverConfig.apiBaseUrl}/$language/api/2/Painting?id=$id"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            Log.d(TAG, "fetchPaintingDetails response: $body")
+            val result = gson.fromJson(body, PaintingDetails::class.java)
+            Log.d(TAG, "fetchPaintingDetails decoded: $result")
+            return result
+        }
+    }
     fun fetchArtistDetails(path: String): ArtistDetails? {
         val url = "${serverConfig.apiBaseUrl}$path?json=2"
         val request = Request.Builder().url(url).build()

--- a/android/app/src/main/res/layout/activity_painting_detail.xml
+++ b/android/app/src/main/res/layout/activity_painting_detail.xml
@@ -40,6 +40,7 @@
             android:visibility="gone"
             android:textAppearance="@style/BodyText" />
 
+
         <TextView
             android:id="@+id/detailDimensions"
             android:layout_width="wrap_content"
@@ -47,6 +48,14 @@
             android:layout_marginTop="2dp"
             android:visibility="gone"
             android:textAppearance="@style/BodyText" />
+
+        <LinearLayout
+            android:id="@+id/detailsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="8dp"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/detailArtist"

--- a/android/app/src/main/res/layout/item_painting_detail_field.xml
+++ b/android/app/src/main/res/layout/item_painting_detail_field.xml
@@ -1,0 +1,21 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingTop="2dp"
+    android:paddingBottom="2dp">
+
+    <TextView
+        android:id="@+id/detailLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textAppearance="@style/CaptionText" />
+
+    <TextView
+        android:id="@+id/detailValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:textAppearance="@style/BodyText" />
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,6 +10,15 @@
     <string name="buy">Buy</string>
     <string name="year">Year: %1$s</string>
     <string name="dimensions">Dimensions: %1$dx%2$d</string>
+    <string name="location_label">Location:</string>
+    <string name="period_label">Period:</string>
+    <string name="series_label">Series:</string>
+    <string name="genres_label">Genres:</string>
+    <string name="styles_label">Styles:</string>
+    <string name="media_label">Media:</string>
+    <string name="galleries_label">Galleries:</string>
+    <string name="tags_label">Tags:</string>
+    <string name="description_label">Description:</string>
     <string name="related_paintings">Related Paintings</string>
 
     <string name="famous_works">Famous Works</string>


### PR DESCRIPTION
## Summary
- fetch painting details from API and expose via repository
- add layout container to show painting details
- display details like location, period, genres, styles, media etc
- update strings for detail labels

## Testing
- `sh ./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b829094d4832e8f666902be007c34