### PR TITLE
Fix search screen keyboard action

### DIFF
--- a/android/app/src/main/res/layout/activity_search.xml
+++ b/android/app/src/main/res/layout/activity_search.xml
@@ -16,6 +16,8 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/search"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
             android:textAppearance="@style/BodyText" />
 
         <ImageButton

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -16,6 +16,8 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/search"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
             android:textAppearance="@style/BodyText" />
 
         <ImageButton


### PR DESCRIPTION
## Summary
- enable keyboard search action in the search layouts

## Testing
- `sh ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b82bf8a00832e8b4692390ab0bffb