### PR TITLE
Update Android artists screen to match iOS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'androidx.paging:paging-runtime:3.2.1'
     implementation 'io.coil-kt:coil:2.5.0'
+    implementation 'com.github.Dimezis:BlurView:version-2.0.6'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation "androidx.room:room-runtime:2.6.1"
     kapt "androidx.room:room-compiler:2.6.1"

--- a/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
@@ -9,6 +9,9 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import android.os.Build
+import eightbitlab.com.blurview.BlurView
+import eightbitlab.com.blurview.RenderEffectBlur
 import com.wikiart.model.Artist
 
 class ArtistAdapter(
@@ -30,6 +33,21 @@ class ArtistAdapter(
         private val worksText: TextView = itemView.findViewById(R.id.artistWorks)
         private val nationText: TextView = itemView.findViewById(R.id.artistNation)
         private val artistImage: ImageView = itemView.findViewById(R.id.artistImage)
+        private val blurView: BlurView = itemView.findViewById(R.id.infoBlur)
+
+        init {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val root = itemView.rootView.findViewById<ViewGroup>(android.R.id.content)
+                val attrs = itemView.context.obtainStyledAttributes(intArrayOf(android.R.attr.windowBackground))
+                val windowBackground = attrs.getDrawable(0)
+                attrs.recycle()
+                blurView.setupWith(root)
+                    .setFrameClearDrawable(windowBackground)
+                    .setBlurAlgorithm(RenderEffectBlur())
+                    .setBlurRadius(itemView.resources.getDimension(R.dimen.detail_blur_radius))
+                    .setHasFixedTransformationMatrix(true)
+            }
+        }
 
         fun bind(artist: Artist) {
             nameText.text = artist.title

--- a/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsActivity.kt
@@ -37,7 +37,8 @@ class ArtistsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_artists)
 
         val recycler: RecyclerView = findViewById(R.id.artistRecyclerView)
-        recycler.layoutManager = GridLayoutManager(this, 2)
+        val columns = if (resources.getBoolean(R.bool.isTablet)) 4 else 2
+        recycler.layoutManager = GridLayoutManager(this, columns)
         recycler.adapter = adapter
 
         val spinner: Spinner = findViewById(R.id.artistCategorySpinner)

--- a/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsFragment.kt
@@ -45,7 +45,8 @@ class ArtistsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         swipeRefreshLayout = view.findViewById(R.id.swipeRefreshLayout)
         val recycler: RecyclerView = view.findViewById(R.id.artistRecyclerView)
-        recycler.layoutManager = GridLayoutManager(requireContext(), 2)
+        val columns = if (resources.getBoolean(R.bool.isTablet)) 4 else 2
+        recycler.layoutManager = GridLayoutManager(requireContext(), columns)
         recycler.adapter = adapter
         swipeRefreshLayout.setOnRefreshListener { adapter.refresh() }
         adapter.addLoadStateListener { loadState ->

--- a/android/app/src/main/res/drawable/artist_info_background.xml
+++ b/android/app/src/main/res/drawable/artist_info_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <solid android:color="#66000000" />
-</shape>

--- a/android/app/src/main/res/layout/list_item_artist.xml
+++ b/android/app/src/main/res/layout/list_item_artist.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp">
@@ -12,14 +13,19 @@
         android:scaleType="centerCrop"
         android:minHeight="@dimen/artist_image_min_height" />
 
-    <LinearLayout
-        android:id="@+id/infoContainer"
+    <eightbitlab.com.blurview.BlurView
+        android:id="@+id/infoBlur"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:orientation="vertical"
-        android:background="@drawable/artist_info_background"
-        android:padding="8dp">
+        app:blurOverlayColor="@color/artist_info_overlay">
+
+        <LinearLayout
+            android:id="@+id/infoContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp">
 
         <TextView
             android:id="@+id/artistName"
@@ -38,6 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/CaptionTextLight" />
-    </LinearLayout>
+        </LinearLayout>
+    </eightbitlab.com.blurview.BlurView>
 
 </FrameLayout>

--- a/android/app/src/main/res/values-sw600dp/bools.xml
+++ b/android/app/src/main/res/values-sw600dp/bools.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="isTablet">true</bool>
+</resources>

--- a/android/app/src/main/res/values/bools.xml
+++ b/android/app/src/main/res/values/bools.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="isTablet">false</bool>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -11,4 +11,6 @@
     <color name="groupBackgroundTranslucent">#CCF2F2F7</color>
     <color name="cardBackground">#FFFFFF</color>
     <color name="imagePlaceholder">#C6C6C8</color>
+    <!-- Overlay color for artist info blur view -->
+    <color name="artist_info_overlay">#66000000</color>
 </resources>


### PR DESCRIPTION
## Summary
- add BlurView for artist item info background like on iOS
- adjust artist grid columns based on tablet/phone
- add BlurView dependency
- remove obsolete artist_info_background drawable

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8501a288832ebf460ea0762ef332