### PR TITLE
Expand Android artist details

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistDetails.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetails.kt
@@ -5,7 +5,11 @@ import java.io.Serializable
 
 data class ArtistDetails(
     @SerializedName("artistName") val artistName: String?,
+    @SerializedName("gender") val gender: String?,
     @SerializedName("biography") val biography: String?,
+    @SerializedName("series") val series: String?,
+    @SerializedName("themes") val themes: String?,
+    @SerializedName("periodsOfWork") val periods: String?,
     @SerializedName("birthDayAsString") val birth: String?,
     @SerializedName("deathDayAsString") val death: String?,
     @SerializedName("image") val image: String?,

--- a/android/app/src/main/res/layout/activity_artist_detail.xml
+++ b/android/app/src/main/res/layout/activity_artist_detail.xml
@@ -25,37 +25,12 @@
             android:layout_marginTop="8dp"
             android:textAppearance="@style/HeadingText" />
 
-        <TextView
-            android:id="@+id/artistBirth"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/detailsContainer"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textAppearance="@style/BodyText"
-            android:visibility="gone" />
-
-        <TextView
-            android:id="@+id/artistDeath"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/BodyText"
-            android:visibility="gone" />
-
-        <TextView
-            android:id="@+id/artistBio"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:maxLines="3"
-            android:ellipsize="end"
-            android:textAppearance="@style/BodyText" />
-
-        <TextView
-            android:id="@+id/bioToggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:text="@string/show_more"
-            android:textColor="@color/colorPrimary" />
+            android:orientation="vertical"
+            android:layout_marginTop="8dp" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/famousRecyclerView"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -69,6 +69,12 @@
     <string name="see_all_paintings">See all paintings</string>
     <string name="born">Born: %1$s</string>
     <string name="died">Died: %1$s</string>
+    <string name="biography_label">Biography:</string>
+    <string name="gender_label">Gender:</string>
+    <string name="themes_label">Themes:</string>
+    <string name="periods_label">Periods:</string>
+    <string name="birth_label">Born:</string>
+    <string name="death_label">Died:</string>
     <string name="change_layout">Change layout</string>
 
     <!-- Transition name used for shared element animations -->


### PR DESCRIPTION
## Summary
- show full artist details to match iOS implementation
- update `ArtistDetails` model with extra fields
- render artist detail fields dynamically in `ArtistDetailActivity`
- update artist detail layout to include a details container
- add new string resources for the extra fields

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b85079494832ea7ddabc9e04ef63b