### PR TITLE
Fix BlurView setup

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
@@ -41,9 +41,8 @@ class ArtistAdapter(
                 val attrs = itemView.context.obtainStyledAttributes(intArrayOf(android.R.attr.windowBackground))
                 val windowBackground = attrs.getDrawable(0)
                 attrs.recycle()
-                blurView.setupWith(root)
+                blurView.setupWith(root, RenderEffectBlur())
                     .setFrameClearDrawable(windowBackground)
-                    .setBlurAlgorithm(RenderEffectBlur())
                     .setBlurRadius(itemView.resources.getDimension(R.dimen.detail_blur_radius))
                     .setHasFixedTransformationMatrix(true)
             }


### PR DESCRIPTION
## Summary
- fix unresolved reference error by passing RenderEffectBlur to `setupWith`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8763acfc832e9a9809610bf8ff76