### PR TITLE
Fix compile error due to removed BlurView API

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
@@ -44,7 +44,6 @@ class ArtistAdapter(
                 blurView.setupWith(root, RenderEffectBlur())
                     .setFrameClearDrawable(windowBackground)
                     .setBlurRadius(itemView.resources.getDimension(R.dimen.detail_blur_radius))
-                    .setHasFixedTransformationMatrix(true)
             }
         }
 


### PR DESCRIPTION
## Summary
- remove deprecated `setHasFixedTransformationMatrix` call

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b88ed133c832e986dee3bf9964571