### PR TITLE
Fix ArtistSearchPagingSource import

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistSearchPagingSource.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistSearchPagingSource.kt
@@ -2,6 +2,7 @@ package com.wikiart
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.wikiart.model.Artist
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 


### PR DESCRIPTION
## Summary
- fix missing Artist import in `ArtistSearchPagingSource`

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b68db30832eadad355d2b1adde6