### PR TITLE
Fix hardware bitmap crash

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistAdapter.kt
@@ -57,7 +57,9 @@ class ArtistAdapter(
             nameText.text = artist.title
             worksText.text = artist.totalWorksTitle?.capitalize()
             nationText.text = listOfNotNull(artist.nation, artist.year).joinToString(", ")
-            artistImage.load(artist.image)
+            artistImage.load(artist.image) {
+                allowHardware(false)
+            }
             itemView.setOnClickListener { onItemClick(artist) }
         }
     }

--- a/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistDetailActivity.kt
@@ -61,7 +61,9 @@ class ArtistDetailActivity : AppCompatActivity() {
             val details = repository.getArtistDetails(artistUrl)
             if (details != null) {
                 findViewById<TextView>(R.id.artistName).text = details.artistName
-                findViewById<ImageView>(R.id.artistImage).load(details.image)
+                findViewById<ImageView>(R.id.artistImage).load(details.image) {
+                    allowHardware(false)
+                }
                 addDetails(detailsContainer, details)
             }
             val paintings = repository.getFamousPaintings(artistUrl)

--- a/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
@@ -23,7 +23,9 @@ class ImageDetailActivity : AppCompatActivity() {
 
         val url = intent.getStringExtra(EXTRA_IMAGE_URL) ?: ""
         val imageView: PhotoView = findViewById(R.id.fullImageView)
-        imageView.load(url)
+        imageView.load(url) {
+            allowHardware(false)
+        }
         imageView.setOnClickListener { finish() }
     }
 

--- a/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingAdapter.kt
@@ -57,7 +57,9 @@ class PaintingAdapter(
                 }
             }
 
-            paintingImage.load(painting.thumbUrl)
+            paintingImage.load(painting.thumbUrl) {
+                allowHardware(false)
+            }
 
             itemView.setOnClickListener { onItemClick(painting, paintingImage) }
         }

--- a/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingDetailActivity.kt
@@ -58,7 +58,9 @@ class PaintingDetailActivity : AppCompatActivity() {
 
         findViewById<TextView>(R.id.detailTitle).text = title
         val detailImage: ImageView = findViewById(R.id.detailImage)
-        detailImage.load(imageUrl)
+        detailImage.load(imageUrl) {
+            allowHardware(false)
+        }
         detailImage.setOnClickListener {
             val intent = Intent(this, ImageDetailActivity::class.java)
             intent.putExtra(ImageDetailActivity.EXTRA_IMAGE_URL, fullUrl)

--- a/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
+++ b/android/app/src/main/java/com/wikiart/RelatedPaintingAdapter.kt
@@ -44,7 +44,9 @@ class RelatedPaintingAdapter(
                 this.width = width
             }
 
-            image.load(painting.thumbUrl)
+            image.load(painting.thumbUrl) {
+                allowHardware(false)
+            }
             itemView.setOnClickListener { onItemClick(painting, image) }
         }
     }


### PR DESCRIPTION
## Summary
- disable Coil hardware bitmaps when loading images

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8ca2f1b4832eb319fafe6dd69bc7