### PR TITLE
Update README docs for bottom sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,27 @@ reference.
 The Android port now displays paintings retrieved from the WikiArt API with
 endless scrolling support powered by the Paging library. Only one page of
 results is fetched at a time and the next page loads after most of the current
-items have been scrolled through. A category spinner
-lets you filter paintings (e.g. Featured or Popular). List items load images
+items have been scrolled through. Categories and layout settings are now
+presented in a bottom sheet invoked from the main screen, replacing the old
+spinner. A simplified mockup is shown below:
+
+```
+Main screen
+-----------
+[filter ⌄] [layout ⌄]
+
+┌ bottom sheet ┐
+│ Featured     │
+│ Popular      │
+│ ...          │
+│ Layout:      │
+│  • List      │
+│  • Grid      │
+│  • Sheet     │
+└──────────────┘
+```
+
+List items load images
 using Coil, and tapping an item opens a detail screen. You can search with
 autocomplete suggestions, mark paintings as favourites, view artist details and
 share or buy prints of a painting. Images can also be viewed full screen with
@@ -26,6 +45,10 @@ ratio just like on iOS.
 
 The latest update adds Material You dynamic color support on Android 12+
 devices, automatically adapting the app theme to the user's wallpaper.
+
+Navigation between Paintings, Artists, Search, Favourites and Support
+continues to be handled by the bottom navigation bar at the bottom of the
+screen.
 
 ## Future improvements
 

--- a/android/README.md
+++ b/android/README.md
@@ -4,15 +4,16 @@ This is an Android port of WikiArt. The `PaintingsFragment` hosts a RecyclerView
 that fetches paintings from the WikiArt API using OkHttp and coroutines.
 Scrolling now loads additional pages automatically using the
 Paging library. Each item displays the painting image using Coil and tapping a
-painting opens a detail screen showing a larger image and the title. A spinner
-at the top allows choosing a painting category and the list updates accordingly.
-A menu or new layout button on the Painting list lets you switch between list, grid and sheet layouts; your choice is saved.
+painting opens a detail screen showing a larger image and the title. Categories
+and layout options are now presented in a bottom sheet launched from the main
+screen, letting you filter paintings or switch between list, grid and sheet
+layouts. Your selection is saved for next time.
 Additional screens let you search with autocomplete, manage favourites and view
 artist information. You can share or buy prints of a painting, view the image in
 full screen and visit a Support screen to send feedback or make a donation using
 Google Play Billing. The bottom navigation bar handles switching between the
-Paintings, Artists, Search and Support fragments, replacing the old options
-menu.
+Paintings, Artists, Search, Favourites and Support fragments, replacing the old
+options menu.
 Material You dynamic colors are applied on Android 12 and above so the app theme
 matches your wallpaper.
 Section titles in category dialogs are shown in your device language when


### PR DESCRIPTION
## Summary
- document that a bottom sheet exposes category and layout options
- add navigation info about Paintings, Artists, Search, Favourites and Support
- update android README with bottom sheet description

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f70dda4832ebe3f033a6c202d7d