### PR TITLE
Introduce Jetpack Compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ devices, automatically adapting the app theme to the user's wallpaper.
 
 - Cache paintings for offline viewing
 - Port additional iOS features such as artwork collections
-- Explore a Jetpack Compose UI rewrite
+- Rewrite the Android interface using Jetpack Compose

--- a/android/README.md
+++ b/android/README.md
@@ -52,4 +52,4 @@ when not present. If the API endpoint values are blank the app defaults to
 
 - Cache API responses locally to allow browsing offline
 - Add push notifications for featured paintings
-- Consider migrating views to Jetpack Compose
+- Begin migrating views to Jetpack Compose for a modern interface

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,6 +34,10 @@ android {
     }
     buildFeatures {
         buildConfig true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion "1.5.4"
     }
     defaultConfig {
         applicationId "com.wikiart"
@@ -82,6 +86,10 @@ dependencies {
     kapt "androidx.room:room-compiler:2.6.1"
     implementation "androidx.room:room-ktx:2.6.1"
     implementation 'com.android.billingclient:billing-ktx:6.1.0'
+    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.activity:activity-compose:1.9.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.mockk:mockk:1.14.2'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
             android:theme="@style/TranslucentDetailTheme" />
         <activity android:name=".ArtistsActivity" />
         <activity android:name=".ArtistPaintingsActivity" />
+        <activity android:name=".ComposeSupportActivity" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/ComposeSupportActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ComposeSupportActivity.kt
@@ -1,0 +1,49 @@
+package com.wikiart
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+class ComposeSupportActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            SupportScreen()
+        }
+    }
+
+    @Composable
+    fun SupportScreen() {
+        MaterialTheme {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_SENDTO).apply {
+                            data = Uri.parse("mailto:wikiartfeedback@icloud.com")
+                        }
+                        startActivity(intent)
+                    }
+                ) {
+                    Text(text = getString(R.string.send_feedback))
+                }
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { /* TODO: show billing options */ }
+                ) {
+                    Text(text = getString(R.string.donate))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- begin rewriting Android UI using Jetpack Compose
- add Compose support activity demonstrating a Support screen
- enable Compose in Gradle build
- update READMEs to note Compose migration

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f82dacc832eb0efabbbf5767e23