### PR TITLE
Convert FavoritesActivity to Jetpack Compose

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'androidx.paging:paging-runtime:3.2.1'
     implementation 'io.coil-kt:coil:2.5.0'
+    implementation 'io.coil-kt:coil-compose:2.5.0'
     implementation 'com.github.Dimezis:BlurView:version-2.0.6'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation "androidx.room:room-runtime:2.6.1"

--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -1,51 +1,88 @@
 package com.wikiart
 
 import android.content.Intent
-import android.app.ActivityOptions
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.paging.PagingData
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import androidx.paging.LoadState
-import android.widget.ImageView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.Alignment
+import coil.compose.AsyncImage
 import com.wikiart.data.FavoritesRepository
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 
-class FavoritesActivity : AppCompatActivity() {
-    private val adapter = PaintingAdapter { painting, image ->
-        val intent = Intent(this, PaintingDetailActivity::class.java)
-        intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-        val options = ActivityOptions.makeSceneTransitionAnimation(
-            this,
-            image,
-            image.transitionName
-        )
-        startActivity(intent, options.toBundle())
-    }
-    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
+class FavoritesActivity : ComponentActivity() {
+    private val repository by lazy { FavoritesRepository(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_favorites)
-
-        swipeRefreshLayout = findViewById(R.id.swipeRefreshLayout)
-        val recyclerView: RecyclerView = findViewById(R.id.favoritesRecyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(this)
-        recyclerView.adapter = adapter
-        swipeRefreshLayout.setOnRefreshListener { adapter.refresh() }
-        adapter.addLoadStateListener { loadState ->
-            swipeRefreshLayout.isRefreshing = loadState.source.refresh is LoadState.Loading
-        }
-
-        val repository = FavoritesRepository(this)
-        lifecycleScope.launch {
-            repository.favoritesFlow().collect { list ->
-                adapter.submitData(lifecycle, PagingData.from(list))
+        setContent {
+            FavoritesScreen { painting ->
+                val intent = Intent(this, PaintingDetailActivity::class.java)
+                intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+                startActivity(intent)
             }
+        }
+    }
+
+    @Composable
+    fun FavoritesScreen(onItemClick: (Painting) -> Unit) {
+        val favorites = repository.favoritesFlow().collectAsState(initial = emptyList())
+        MaterialTheme {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(favorites.value, key = { it.id }) { painting ->
+                    PaintingItem(painting, onItemClick)
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun PaintingItem(painting: Painting, onClick: (Painting) -> Unit) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onClick(painting) }
+                .padding(16.dp)
+        ) {
+            AsyncImage(
+                model = painting.thumbUrl,
+                contentDescription = painting.title,
+                contentScale = ContentScale.FillWidth,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = painting.artistName,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp)
+            )
+            Text(
+                text = painting.title,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
+            Text(
+                text = painting.year,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor FavoritesActivity to use Jetpack Compose
- load images with `coil-compose`
- update Gradle dependencies for Compose image loading

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b90b25aa0832eba746c010f46976a