### PR TITLE
Fix Compose compiler mismatch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.5.4"
+        kotlinCompilerExtensionVersion "1.5.14"
     }
     defaultConfig {
         applicationId "com.wikiart"


### PR DESCRIPTION
## Summary
- bump Compose compiler to 1.5.14 so it's compatible with Kotlin 1.9.24

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b91348228832e8c8330de2927df82