### PR TITLE
Remove legacy top bars and add options sheet

### DIFF
--- a/android/app/src/main/java/com/wikiart/OptionsBottomSheet.kt
+++ b/android/app/src/main/java/com/wikiart/OptionsBottomSheet.kt
@@ -1,0 +1,54 @@
+package com.wikiart
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.RadioGroup
+import android.widget.Spinner
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.wikiart.model.LayoutType
+
+class OptionsBottomSheet<T : CategoryItem>(
+    private val categories: Array<T>? = null,
+    private var selectedCategory: T? = null,
+    private var layoutType: LayoutType,
+    private val callback: (T?, LayoutType) -> Unit
+) : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.bottom_sheet_options, container, false)
+        val spinner = view.findViewById<Spinner>(R.id.categorySpinner)
+        if (categories.isNullOrEmpty()) {
+            spinner.visibility = View.GONE
+        } else {
+            val adapter = CategorySpinnerAdapter(requireContext(), categories)
+            spinner.adapter = adapter
+            spinner.setSelection(categories.indexOf(selectedCategory))
+        }
+
+        val group = view.findViewById<RadioGroup>(R.id.layoutGroup)
+        when (layoutType) {
+            LayoutType.LIST -> group.check(R.id.layoutList)
+            LayoutType.SHEET -> group.check(R.id.layoutSheet)
+            else -> group.check(R.id.layoutGrid)
+        }
+
+        view.findViewById<Button>(R.id.applyButton).setOnClickListener {
+            val category = if (categories.isNullOrEmpty()) null else categories[spinner.selectedItemPosition]
+            val layout = when (group.checkedRadioButtonId) {
+                R.id.layoutList -> LayoutType.LIST
+                R.id.layoutSheet -> LayoutType.SHEET
+                else -> LayoutType.COLUMN
+            }
+            callback(category, layout)
+            dismiss()
+        }
+        return view
+    }
+}

--- a/android/app/src/main/java/com/wikiart/SearchFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SearchFragment.kt
@@ -3,14 +3,9 @@ package com.wikiart
 import android.content.Intent
 import android.app.ActivityOptions
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.EditorInfo
-import android.widget.ArrayAdapter
-import android.widget.AutoCompleteTextView
 import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -27,12 +22,15 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import android.content.Context
-import androidx.appcompat.widget.PopupMenu
 import com.wikiart.model.LayoutType
+import com.wikiart.OptionsBottomSheet
+import com.wikiart.PaintingCategory
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 
 class SearchFragment : Fragment() {
     private var layoutType: LayoutType = LayoutType.COLUMN
-    private lateinit var layoutButton: View
     private lateinit var recyclerView: RecyclerView
     private val paintingAdapter = PaintingAdapter(layoutType) { painting, image ->
         val intent = Intent(requireContext(), PaintingDetailActivity::class.java)
@@ -64,15 +62,14 @@ class SearchFragment : Fragment() {
     private lateinit var swipeRefreshLayout: SwipeRefreshLayout
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_search, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val input: AutoCompleteTextView = view.findViewById(R.id.searchInput)
         swipeRefreshLayout = view.findViewById(R.id.swipeRefreshLayout)
         recyclerView = view.findViewById(R.id.resultsRecyclerView)
-        layoutButton = view.findViewById(R.id.layoutButton)
 
         val prefs = requireContext().getSharedPreferences("prefs", Context.MODE_PRIVATE)
         val name = prefs.getString("layout_type", LayoutType.COLUMN.name) ?: LayoutType.COLUMN.name
@@ -81,7 +78,6 @@ class SearchFragment : Fragment() {
         recyclerView.layoutManager = layoutManagerFor(layoutType)
         paintingAdapter.layoutType = layoutType
         recyclerView.adapter = concatAdapter
-        layoutButton.setOnClickListener { showLayoutMenu(it) }
         swipeRefreshLayout.setOnRefreshListener {
             paintingAdapter.refresh()
             artistAdapter.refresh()
@@ -110,39 +106,6 @@ class SearchFragment : Fragment() {
                     .show()
             }
         }
-
-        val suggestions = ArrayAdapter<String>(requireContext(), android.R.layout.simple_dropdown_item_1line)
-        input.setAdapter(suggestions)
-
-        input.setOnEditorActionListener { _, actionId, _ ->
-            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
-                performSearch(input.text.toString())
-                true
-            } else {
-                false
-            }
-        }
-
-        input.setOnItemClickListener { _, _, position, _ ->
-            val term = suggestions.getItem(position) ?: return@setOnItemClickListener
-            performSearch(term)
-        }
-
-        input.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                val text = s?.toString() ?: return
-                if (text.length >= 2) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        val autos = repository.autoComplete(text)
-                        suggestions.clear()
-                        suggestions.addAll(autos.map { it.label })
-                        suggestions.notifyDataSetChanged()
-                    }
-                }
-            }
-            override fun afterTextChanged(s: Editable?) {}
-        })
     }
 
     private fun performSearch(term: String) {
@@ -171,24 +134,31 @@ class SearchFragment : Fragment() {
         else -> LinearLayoutManager(requireContext())
     }
 
-    private fun showLayoutMenu(anchor: View) {
-        PopupMenu(requireContext(), anchor).apply {
-            menuInflater.inflate(R.menu.layout_menu, menu)
-            setOnMenuItemClickListener { item ->
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.options_menu, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_options -> {
+                showOptionsSheet()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun showOptionsSheet() {
+        OptionsBottomSheet<PaintingCategory>(null, null, layoutType) { _, layout ->
+            if (layout != layoutType) {
                 val prefs = requireContext().getSharedPreferences("prefs", Context.MODE_PRIVATE)
-                layoutType = when (item.itemId) {
-                    R.id.layout_list -> LayoutType.LIST
-                    R.id.layout_grid -> LayoutType.COLUMN
-                    R.id.layout_sheet -> LayoutType.SHEET
-                    else -> return@setOnMenuItemClickListener false
-                }
+                layoutType = layout
                 prefs.edit().putString("layout_type", layoutType.name).apply()
                 paintingAdapter.layoutType = layoutType
                 paintingAdapter.notifyDataSetChanged()
                 recyclerView.layoutManager = layoutManagerFor(layoutType)
-                true
             }
-            show()
-        }
+        }.show(parentFragmentManager, "options")
     }
 }

--- a/android/app/src/main/res/layout/activity_search.xml
+++ b/android/app/src/main/res/layout/activity_search.xml
@@ -4,31 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/groupBackground">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <AutoCompleteTextView
-            android:id="@+id/searchInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:hint="@string/search"
-            android:imeOptions="actionSearch"
-            android:inputType="text"
-            android:textAppearance="@style/BodyText" />
-
-        <ImageButton
-            android:id="@+id/layoutButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/change_layout"
-            android:src="@drawable/ic_gallery"
-            android:background="?attr/selectableItemBackgroundBorderless" />
-    </LinearLayout>
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/resultsRecyclerView"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/bottom_sheet_options.xml
+++ b/android/app/src/main/res/layout/bottom_sheet_options.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Spinner
+        android:id="@+id/categorySpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <RadioGroup
+        android:id="@+id/layoutGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="16dp">
+
+        <RadioButton
+            android:id="@+id/layoutList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="List" />
+
+        <RadioButton
+            android:id="@+id/layoutGrid"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Grid" />
+
+        <RadioButton
+            android:id="@+id/layoutSheet"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sheet" />
+    </RadioGroup>
+
+    <Button
+        android:id="@+id/applyButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@android:string/ok" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_artists.xml
+++ b/android/app/src/main/res/layout/fragment_artists.xml
@@ -3,12 +3,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-
-    <Spinner
-        android:id="@+id/artistCategorySpinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_paintings.xml
+++ b/android/app/src/main/res/layout/fragment_paintings.xml
@@ -4,27 +4,6 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@color/groupBackground">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <Spinner
-            android:id="@+id/categorySpinner"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1" />
-
-        <ImageButton
-            android:id="@+id/layoutButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/change_layout"
-            android:src="@drawable/ic_gallery"
-            android:background="?attr/selectableItemBackgroundBorderless" />
-    </LinearLayout>
-
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -4,31 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/groupBackground">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <AutoCompleteTextView
-            android:id="@+id/searchInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:hint="@string/search"
-            android:imeOptions="actionSearch"
-            android:inputType="text"
-            android:textAppearance="@style/BodyText" />
-
-        <ImageButton
-            android:id="@+id/layoutButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/change_layout"
-            android:src="@drawable/ic_gallery"
-            android:background="?attr/selectableItemBackgroundBorderless" />
-    </LinearLayout>
-
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/menu/options_menu.xml
+++ b/android/app/src/main/res/menu/options_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_options"
+        android:title="@string/change_layout"
+        android:icon="@drawable/ic_gallery"
+        android:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
## Summary
- delete spinner and search bars from layouts
- drop outdated view references in fragments and activity
- add a reusable `OptionsBottomSheet`
- open the sheet via toolbar menu item

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f6fae34832ead4d61721ee6bc7f