### PR TITLE
Migrate SupportFragment to Compose

### DIFF
--- a/android/app/src/main/java/com/wikiart/ComposeSupportActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ComposeSupportActivity.kt
@@ -5,45 +5,20 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 class ComposeSupportActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            SupportScreen()
-        }
-    }
-
-    @Composable
-    fun SupportScreen() {
-        MaterialTheme {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Button(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        val intent = Intent(Intent.ACTION_SENDTO).apply {
-                            data = Uri.parse("mailto:wikiartfeedback@icloud.com")
-                        }
-                        startActivity(intent)
+            SupportScreen(
+                onSendFeedback = {
+                    val intent = Intent(Intent.ACTION_SENDTO).apply {
+                        data = Uri.parse("mailto:wikiartfeedback@icloud.com")
                     }
-                ) {
-                    Text(text = getString(R.string.send_feedback))
-                }
-                Spacer(Modifier.height(12.dp))
-                Button(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = { /* TODO: show billing options */ }
-                ) {
-                    Text(text = getString(R.string.donate))
-                }
-            }
+                    startActivity(intent)
+                },
+                onDonate = { /* TODO: show billing options */ }
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/wikiart/SupportFragment.kt
+++ b/android/app/src/main/java/com/wikiart/SupportFragment.kt
@@ -6,9 +6,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.compose.ui.platform.ComposeView
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
@@ -30,7 +30,19 @@ class SupportFragment : Fragment(), PurchasesUpdatedListener {
     )
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return inflater.inflate(R.layout.fragment_support, container, false)
+        return ComposeView(requireContext()).apply {
+            setContent {
+                SupportScreen(
+                    onSendFeedback = {
+                        val intent = Intent(Intent.ACTION_SENDTO).apply {
+                            data = Uri.parse("mailto:wikiartfeedback@icloud.com")
+                        }
+                        startActivity(intent)
+                    },
+                    onDonate = { queryProductsAndShowDialog() }
+                )
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -44,16 +56,7 @@ class SupportFragment : Fragment(), PurchasesUpdatedListener {
             override fun onBillingServiceDisconnected() {}
         })
 
-        view.findViewById<Button>(R.id.feedbackButton).setOnClickListener {
-            val intent = Intent(Intent.ACTION_SENDTO).apply {
-                data = Uri.parse("mailto:wikiartfeedback@icloud.com")
-            }
-            startActivity(intent)
-        }
-
-        view.findViewById<Button>(R.id.donateButton).setOnClickListener {
-            queryProductsAndShowDialog()
-        }
+        // No view IDs to initialize when using Compose UI
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/wikiart/SupportScreen.kt
+++ b/android/app/src/main/java/com/wikiart/SupportScreen.kt
@@ -1,0 +1,34 @@
+package com.wikiart
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SupportScreen(
+    onSendFeedback: () -> Unit,
+    onDonate: () -> Unit
+) {
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onSendFeedback
+            ) {
+                Text(text = stringResource(R.string.send_feedback))
+            }
+            Spacer(Modifier.height(12.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onDonate
+            ) {
+                Text(text = stringResource(R.string.donate))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert SupportFragment to use Compose via ComposeView
- move Support screen UI into reusable `SupportScreen` composable
- update ComposeSupportActivity to use the new composable

## Testing
- `sh ./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b91ceaac0832e9b3ed702c2daef74