### PR TITLE
Fix FavoritesScreen call

### DIFF
--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -11,11 +11,11 @@ class FavoritesActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            FavoritesScreen { painting ->
+            FavoritesScreen(onItemClick = { painting ->
                 val intent = Intent(this, PaintingDetailActivity::class.java)
                 intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
                 startActivity(intent)
-            }
+            })
         }
     }
 


### PR DESCRIPTION
## Summary
- specify `onItemClick` argument when calling `FavoritesScreen`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b94618a38832e910fa50e7312c7e5