### PR TITLE
Fix FavoritesActivity compile error

### DIFF
--- a/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
+++ b/android/app/src/main/java/com/wikiart/FavoritesActivity.kt
@@ -11,11 +11,13 @@ class FavoritesActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            FavoritesScreen { painting ->
-                val intent = Intent(this, PaintingDetailActivity::class.java)
-                intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
-                startActivity(intent)
-            }
+            FavoritesScreen(
+                onItemClick = { painting ->
+                    val intent = Intent(this, PaintingDetailActivity::class.java)
+                    intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+                    startActivity(intent)
+                }
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- pass `onItemClick` using named parameter in `FavoritesActivity`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b946bda8c832ea0d8166ad0ae0f6a