### PR TITLE
Continue Compose migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Main screen
 
 The iOS project now contains a similar implementation in `View Controller/OptionsBottomSheet.swift` so both platforms share the bottom sheet UI.
 A Compose-based `OptionsBottomSheet` in `ComposeOptionsBottomSheet.kt` allows Compose screens to reuse the same interface on Android.
+Search results are also rendered with Compose, featuring a simple search bar and paginated artist and painting lists.
 
 List items load images
 using Coil, and tapping an item opens a detail screen. You can search with

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'androidx.paging:paging-runtime:3.2.1'
+    implementation 'androidx.paging:paging-compose:3.2.1'
     implementation 'io.coil-kt:coil:2.5.0'
     implementation 'io.coil-kt:coil-compose:2.5.0'
     implementation 'com.github.Dimezis:BlurView:version-2.0.6'

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -44,7 +44,21 @@ class MainActivity : ComponentActivity() {
                     when (selected) {
                         NavItem.Paintings -> PaintingsPlaceholderScreen(Modifier.padding(inner))
                         NavItem.Artists -> ArtistsPlaceholderScreen(Modifier.padding(inner))
-                        NavItem.Search -> SearchPlaceholderScreen(Modifier.padding(inner))
+                        NavItem.Search -> SearchScreen(
+                            modifier = Modifier.padding(inner),
+                            onPaintingClick = { painting ->
+                                val intent = Intent(this, PaintingDetailActivity::class.java)
+                                intent.putExtra(PaintingDetailActivity.EXTRA_PAINTING, painting)
+                                startActivity(intent)
+                            },
+                            onArtistClick = { artist ->
+                                val intent = Intent(this, ArtistDetailActivity::class.java)
+                                intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, artist.artistUrl)
+                                intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artist.title)
+                                startActivity(intent)
+                                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+                            }
+                        )
                         NavItem.Favorites -> FavoritesScreen(
                             onItemClick = { painting ->
                                 val intent = Intent(this, PaintingDetailActivity::class.java)

--- a/android/app/src/main/java/com/wikiart/SearchScreen.kt
+++ b/android/app/src/main/java/com/wikiart/SearchScreen.kt
@@ -1,0 +1,179 @@
+package com.wikiart
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
+import coil.compose.AsyncImage
+import com.wikiart.model.Artist
+
+@Composable
+fun SearchScreen(
+    modifier: Modifier = Modifier,
+    onPaintingClick: (Painting) -> Unit,
+    onArtistClick: (Artist) -> Unit,
+    repository: PaintingRepository = PaintingRepository(LocalContext.current)
+) {
+    var query by remember { mutableStateOf("") }
+    val artistItems = if (query.isNotBlank())
+        repository.searchArtistsPagingFlow(query).collectAsLazyPagingItems() else null
+    val paintingItems = if (query.isNotBlank())
+        repository.searchPagingFlow(query).collectAsLazyPagingItems() else null
+
+    MaterialTheme {
+        Column(modifier = modifier.fillMaxSize()) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                singleLine = true,
+                placeholder = { Text(stringResource(R.string.search)) }
+            )
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                artistItems?.let { artists ->
+                    if (artists.itemCount > 0) {
+                        item {
+                            Text(
+                                text = stringResource(R.string.artists),
+                                modifier = Modifier.padding(16.dp)
+                            )
+                        }
+                    }
+                    items(artists.itemCount) { index ->
+                        artists[index]?.let { artist ->
+                            ArtistRow(artist, onArtistClick)
+                        }
+                    }
+                    if (artists.loadState.append is LoadState.Loading) {
+                        item { LoadingRow() }
+                    }
+                }
+                paintingItems?.let { paintings ->
+                    if (paintings.itemCount > 0) {
+                        item {
+                            Text(
+                                text = stringResource(R.string.paintings),
+                                modifier = Modifier.padding(16.dp)
+                            )
+                        }
+                    }
+                    items(paintings.itemCount) { index ->
+                        paintings[index]?.let { painting ->
+                            PaintingRow(painting, onPaintingClick)
+                        }
+                    }
+                    if (paintings.loadState.append is LoadState.Loading) {
+                        item { LoadingRow() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.Center
+    ) { CircularProgressIndicator() }
+}
+
+@Composable
+private fun PaintingRow(painting: Painting, onClick: (Painting) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(painting) }
+            .padding(16.dp)
+    ) {
+        AsyncImage(
+            model = painting.thumbUrl,
+            contentDescription = painting.title,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Text(
+            text = painting.artistName,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 8.dp)
+        )
+        Text(
+            text = painting.title,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 2.dp)
+        )
+        Text(
+            text = painting.year,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 2.dp)
+        )
+    }
+}
+
+@Composable
+private fun ArtistRow(artist: Artist, onClick: (Artist) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(artist) }
+            .padding(16.dp)
+    ) {
+        artist.image?.let { url ->
+            AsyncImage(
+                model = url,
+                contentDescription = artist.title,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        artist.title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp)
+            )
+        }
+        val works = artist.totalWorksTitle?.replaceFirstChar { c -> c.uppercaseChar() }
+        if (!works.isNullOrBlank()) {
+            Text(
+                text = works,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
+        }
+        val info = listOfNotNull(artist.nation, artist.year).joinToString(", ")
+        if (info.isNotBlank()) {
+            Text(
+                text = info,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert search screen to Jetpack Compose
- update main activity to use new `SearchScreen`
- document Compose search in README
- depend on paging-compose

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b96221ef8832e80e00cd6e51ff01e