### PR TITLE
Add Compose artists screen

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -1,0 +1,134 @@
+package com.wikiart
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.items
+import com.wikiart.model.Artist
+import com.wikiart.model.ArtistCategory
+import com.wikiart.model.LayoutType
+
+@Composable
+fun ArtistsScreen(
+    modifier: Modifier = Modifier,
+    onArtistClick: (Artist) -> Unit,
+    repository: PaintingRepository = PaintingRepository(LocalContext.current)
+) {
+    var category by remember { mutableStateOf(ArtistCategory.POPULAR) }
+    var layoutType by remember { mutableStateOf(LayoutType.COLUMN) }
+    var showOptions by remember { mutableStateOf(false) }
+
+    val artists = remember(category) { repository.artistsPagingFlow(category) }
+        .collectAsLazyPagingItems()
+
+    MaterialTheme {
+        Box(modifier = modifier.fillMaxSize()) {
+            Column {
+                Button(
+                    onClick = { showOptions = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text(text = stringResource(id = category.nameRes()))
+                }
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(artists, key = { it.id }) { artist ->
+                        artist?.let { ArtistRow(it, onArtistClick) }
+                    }
+                    if (artists.loadState.append is LoadState.Loading) {
+                        item { LoadingRow() }
+                    }
+                }
+            }
+            if (showOptions) {
+                OptionsBottomSheet(
+                    categories = ArtistCategory.values(),
+                    selectedCategory = category,
+                    layoutType = layoutType,
+                    onApply = { cat, layout ->
+                        cat?.let { category = it }
+                        layoutType = layout
+                    },
+                    onDismiss = { showOptions = false }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.Center
+    ) { CircularProgressIndicator() }
+}
+
+@Composable
+private fun ArtistRow(artist: Artist, onClick: (Artist) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(artist) }
+            .padding(16.dp)
+    ) {
+        artist.image?.let { url ->
+            coil.compose.AsyncImage(
+                model = url,
+                contentDescription = artist.title,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        artist.title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp)
+            )
+        }
+        val works = artist.totalWorksTitle?.replaceFirstChar { c -> c.uppercaseChar() }
+        if (!works.isNullOrBlank()) {
+            Text(
+                text = works,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
+        }
+        val info = listOfNotNull(artist.nation, artist.year).joinToString(", ")
+        if (info.isNotBlank()) {
+            Text(
+                text = info,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 2.dp)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/wikiart/MainActivity.kt
+++ b/android/app/src/main/java/com/wikiart/MainActivity.kt
@@ -43,7 +43,16 @@ class MainActivity : ComponentActivity() {
                 ) { inner ->
                     when (selected) {
                         NavItem.Paintings -> PaintingsPlaceholderScreen(Modifier.padding(inner))
-                        NavItem.Artists -> ArtistsPlaceholderScreen(Modifier.padding(inner))
+                        NavItem.Artists -> ArtistsScreen(
+                            modifier = Modifier.padding(inner),
+                            onArtistClick = { artist ->
+                                val intent = Intent(this, ArtistDetailActivity::class.java)
+                                intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_URL, artist.artistUrl)
+                                intent.putExtra(ArtistDetailActivity.EXTRA_ARTIST_NAME, artist.title)
+                                startActivity(intent)
+                                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+                            }
+                        )
                         NavItem.Search -> SearchScreen(
                             modifier = Modifier.padding(inner),
                             onPaintingClick = { painting ->


### PR DESCRIPTION
## Summary
- implement new `ArtistsScreen` using Jetpack Compose
- show the Compose artists screen in `MainActivity`

## Testing
- `bash ./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b97e10d28832e93be03f130d7dbcd