### PR TITLE
Fix ArtistsScreen paging items import

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -22,7 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items
+import androidx.paging.compose.items as pagingItems
 import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
 import com.wikiart.model.LayoutType
@@ -52,7 +51,7 @@ fun ArtistsScreen(
                     Text(text = stringResource(id = category.nameRes()))
                 }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(artists, key = { it.id }) { artist ->
+                    pagingItems(artists, key = { it.id }) { artist ->
                         artist?.let { ArtistRow(it, onArtistClick) }
                     }
                     if (artists.loadState.append is LoadState.Loading) {


### PR DESCRIPTION
## Summary
- fix the `items` import for paging

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b1ed744832e88a52fb6a958e311