### PR TITLE
Add layout options for ArtistsScreen

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -1,5 +1,6 @@
 package com.wikiart
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,6 +10,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -22,10 +29,12 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items as pagingItems
+import coil.compose.AsyncImage
 import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
 import com.wikiart.model.LayoutType
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ArtistsScreen(
     modifier: Modifier = Modifier,
@@ -50,12 +59,52 @@ fun ArtistsScreen(
                 ) {
                     Text(text = stringResource(id = category.nameRes()))
                 }
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    pagingItems(artists, key = { it.id }) { artist ->
-                        artist?.let { ArtistRow(it, onArtistClick) }
+                when (layoutType) {
+                    LayoutType.LIST -> {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            pagingItems(artists, key = { it.id }) { artist ->
+                                artist?.let { ArtistRow(it, onArtistClick) }
+                            }
+                            if (artists.loadState.append is LoadState.Loading) {
+                                item { LoadingRow() }
+                            }
+                        }
                     }
-                    if (artists.loadState.append is LoadState.Loading) {
-                        item { LoadingRow() }
+                    LayoutType.COLUMN -> {
+                        LazyVerticalStaggeredGrid(
+                            columns = StaggeredGridCells.Fixed(2),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(artists.itemCount) { index ->
+                                artists[index]?.let { ArtistGridItem(it, onArtistClick) }
+                            }
+                            if (artists.loadState.append is LoadState.Loading) {
+                                item { LoadingRow() }
+                            }
+                        }
+                    }
+                    LayoutType.SHEET -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(artists.itemCount) { index ->
+                                artists[index]?.let { ArtistSheetItem(it, onArtistClick) }
+                            }
+                            if (artists.loadState.append is LoadState.Loading) {
+                                item { LoadingRow() }
+                            }
+                        }
+                    }
+                    else -> {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            pagingItems(artists, key = { it.id }) { artist ->
+                                artist?.let { ArtistRow(it, onArtistClick) }
+                            }
+                            if (artists.loadState.append is LoadState.Loading) {
+                                item { LoadingRow() }
+                            }
+                        }
                     }
                 }
             }
@@ -127,6 +176,67 @@ private fun ArtistRow(artist: Artist, onClick: (Artist) -> Unit) {
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(top = 2.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArtistGridItem(artist: Artist, onClick: (Artist) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable { onClick(artist) },
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        artist.image?.let { url ->
+            AsyncImage(
+                model = url,
+                contentDescription = artist.title,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        artist.title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+        val works = artist.totalWorksTitle?.replaceFirstChar { c -> c.uppercaseChar() }
+        if (!works.isNullOrBlank()) {
+            Text(
+                text = works,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+        val info = listOfNotNull(artist.nation, artist.year).joinToString(", ")
+        if (info.isNotBlank()) {
+            Text(
+                text = info,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArtistSheetItem(artist: Artist, onClick: (Artist) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(2.dp)
+            .clickable { onClick(artist) },
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        artist.image?.let { url ->
+            AsyncImage(
+                model = url,
+                contentDescription = artist.title,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }


### PR DESCRIPTION
## Summary
- add grid and sheet layouts to `ArtistsScreen`
- include new `ArtistGridItem` and `ArtistSheetItem` composables
- annotate screen with `ExperimentalFoundationApi`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9f3a60c4832e8f33f2d1e68f78b3