### PR TITLE
Fix paging compose item imports

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -75,7 +75,7 @@ fun ArtistsScreen(
                             columns = StaggeredGridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            items(artists.itemCount) { index ->
+                            staggeredItems(artists.itemCount) { index ->
                                 artists[index]?.let { ArtistGridItem(it, onArtistClick) }
                             }
                             if (artists.loadState.append is LoadState.Loading) {
@@ -88,7 +88,7 @@ fun ArtistsScreen(
                             columns = GridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            items(artists.itemCount) { index ->
+                            gridItems(artists.itemCount) { index ->
                                 artists[index]?.let { ArtistSheetItem(it, onArtistClick) }
                             }
                             if (artists.loadState.append is LoadState.Loading) {

--- a/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items
+import androidx.paging.compose.items as pagingItems
 import coil.compose.AsyncImage
 import com.wikiart.model.LayoutType
 
@@ -47,7 +47,7 @@ fun PaintingsScreen(
             when (layoutType) {
                 LayoutType.LIST -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(paintings, key = { it.id }) { painting ->
+                        pagingItems(paintings, key = { it.id }) { painting ->
                             painting?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
@@ -62,7 +62,7 @@ fun PaintingsScreen(
                         state = state,
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        items(paintings, key = { it.id }) { painting ->
+                        pagingItems(paintings, key = { it.id }) { painting ->
                             painting?.let { PaintingGridItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
@@ -75,7 +75,7 @@ fun PaintingsScreen(
                         columns = GridCells.Fixed(2),
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        items(paintings, key = { it.id }) { painting ->
+                        pagingItems(paintings, key = { it.id }) { painting ->
                             painting?.let { PaintingSheetItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
@@ -85,7 +85,7 @@ fun PaintingsScreen(
                 }
                 else -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(paintings, key = { it.id }) { painting ->
+                        pagingItems(paintings, key = { it.id }) { painting ->
                             painting?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {


### PR DESCRIPTION
## Summary
- alias paging compose `items` to `pagingItems`
- adjust grid and staggered grid item calls to avoid ambiguity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba1bc9ec0832e8695ba068690426d