### PR TITLE
Fix compose dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation 'com.android.billingclient:billing-ktx:6.1.0'
     implementation platform('androidx.compose:compose-bom:2024.05.00')
     implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.foundation:foundation'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.activity:activity-compose:1.9.0'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## Summary
- add `androidx.compose.foundation` dependency to fix unresolved reference

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba999afb0832eaca156487c613850