### PR TITLE
Rewrite more views with Compose

### DIFF
--- a/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/wikiart/ImageDetailActivity.kt
@@ -5,28 +5,28 @@ import android.os.Bundle
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import coil.load
 import com.github.chrisbanes.photoview.PhotoView
 
-class ImageDetailActivity : AppCompatActivity() {
+class ImageDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_image_detail)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(
                 resources.getDimensionPixelSize(R.dimen.detail_blur_radius)
             )
         }
-
-        enterImmersiveMode()
-
         val url = intent.getStringExtra(EXTRA_IMAGE_URL) ?: ""
-        val imageView: PhotoView = findViewById(R.id.fullImageView)
-        imageView.load(url) {
-            allowHardware(false)
+        enterImmersiveMode()
+        setContent {
+            ImageDetailScreen(imageUrl = url, onClose = { finish() })
         }
-        imageView.setOnClickListener { finish() }
     }
 
     override fun finish() {
@@ -57,6 +57,23 @@ class ImageDetailActivity : AppCompatActivity() {
             @Suppress("DEPRECATION")
             window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
         }
+    }
+
+    @Composable
+    private fun ImageDetailScreen(imageUrl: String, onClose: () -> Unit) {
+        AndroidView(
+            factory = { context ->
+                PhotoView(context).apply {
+                    layoutParams = android.view.ViewGroup.LayoutParams(
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                    )
+                    load(imageUrl) { allowHardware(false) }
+                    setOnClickListener { onClose() }
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
     }
 
     companion object {

--- a/android/app/src/main/java/com/wikiart/StoreActivity.kt
+++ b/android/app/src/main/java/com/wikiart/StoreActivity.kt
@@ -4,22 +4,31 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
 
-class StoreActivity : AppCompatActivity() {
+class StoreActivity : ComponentActivity() {
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_store)
-
-        val webView: WebView = findViewById(R.id.storeWebView)
-        webView.settings.javaScriptEnabled = true
-        webView.webViewClient = WebViewClient()
-
         val imageUrl = intent.getStringExtra(EXTRA_IMAGE_URL) ?: ""
-        val url = "https://www.canvaspop.com/upload?imageUrl=$imageUrl"
-        webView.loadUrl(url)
+        setContent {
+            StoreScreen(imageUrl)
+        }
+    }
+
+    @Composable
+    private fun StoreScreen(imageUrl: String) {
+        AndroidView(factory = { context ->
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = WebViewClient()
+                loadUrl("https://www.canvaspop.com/upload?imageUrl=$imageUrl")
+            }
+        })
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- convert `StoreActivity` and `ImageDetailActivity` to `ComponentActivity`
- implement composable UIs using `AndroidView` wrappers for `WebView` and `PhotoView`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba9059288832e955530f4227815da