### PR TITLE
Add Compose activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity android:name=".ArtistsActivity" />
         <activity android:name=".ArtistPaintingsActivity" />
         <activity android:name=".ComposeSupportActivity" />
+        <activity android:name=".HelloComposeActivity" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/com/wikiart/HelloComposeActivity.kt
+++ b/android/app/src/main/java/com/wikiart/HelloComposeActivity.kt
@@ -1,0 +1,24 @@
+package com.wikiart
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+class HelloComposeActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Greeting()
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting() {
+    Text("Hello Compose!")
+}


### PR DESCRIPTION
## Summary
- add a simple `HelloComposeActivity` as a Compose example
- register the new activity in `AndroidManifest.xml`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bab569c8c832ea7eef85ab1678113