### PR TITLE
Fix Compose paging imports

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsScreen.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -21,7 +23,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items as pagingItems
 import coil.compose.AsyncImage
 import com.wikiart.model.ArtistPaintingSort
 import com.wikiart.model.LayoutType
@@ -49,8 +50,11 @@ fun ArtistPaintingsScreen(
                 when (layoutType) {
                     LayoutType.LIST -> {
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
-                            pagingItems(paintings, key = { it.id }) { painting ->
-                                painting?.let { PaintingColumnItem(it, onPaintingClick) }
+                            items(
+                                count = paintings.itemCount,
+                                key = { index -> paintings[index]?.id }
+                            ) { index ->
+                                paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                             }
                             if (paintings.loadState.append is LoadState.Loading) {
                                 item { LoadingRow() }
@@ -62,8 +66,11 @@ fun ArtistPaintingsScreen(
                             columns = StaggeredGridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            pagingItems(paintings, key = { it.id }) { painting ->
-                                painting?.let { PaintingGridItem(it, onPaintingClick) }
+                            items(
+                                count = paintings.itemCount,
+                                key = { index -> paintings[index]?.id }
+                            ) { index ->
+                                paintings[index]?.let { PaintingGridItem(it, onPaintingClick) }
                             }
                             if (paintings.loadState.append is LoadState.Loading) {
                                 item { LoadingRow() }
@@ -84,14 +91,17 @@ fun ArtistPaintingsScreen(
                         }
                     }
                     else -> {
-                        LazyColumn(modifier = Modifier.fillMaxSize()) {
-                            pagingItems(paintings, key = { it.id }) { painting ->
-                                painting?.let { PaintingColumnItem(it, onPaintingClick) }
-                            }
-                            if (paintings.loadState.append is LoadState.Loading) {
-                                item { LoadingRow() }
-                            }
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(
+                            count = paintings.itemCount,
+                            key = { index -> paintings[index]?.id }
+                        ) { index ->
+                            paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
+                        if (paintings.loadState.append is LoadState.Loading) {
+                            item { LoadingRow() }
+                        }
+                    }
                     }
                 }
             }

--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -10,11 +10,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -27,7 +29,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items as pagingItems
 import coil.compose.AsyncImage
 import com.wikiart.model.Artist
 import com.wikiart.model.ArtistCategory
@@ -61,8 +62,11 @@ fun ArtistsScreen(
                 when (layoutType) {
                     LayoutType.LIST -> {
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
-                            pagingItems(artists, key = { it.id }) { artist ->
-                                artist?.let { ArtistRow(it, onArtistClick) }
+                            items(
+                                count = artists.itemCount,
+                                key = { index -> artists[index]?.id }
+                            ) { index ->
+                                artists[index]?.let { ArtistRow(it, onArtistClick) }
                             }
                             if (artists.loadState.append is LoadState.Loading) {
                                 item { LoadingRow() }
@@ -74,8 +78,11 @@ fun ArtistsScreen(
                             columns = StaggeredGridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            pagingItems(artists, key = { it.id }) { artist ->
-                                artist?.let { ArtistGridItem(it, onArtistClick) }
+                            items(
+                                count = artists.itemCount,
+                                key = { index -> artists[index]?.id }
+                            ) { index ->
+                                artists[index]?.let { ArtistGridItem(it, onArtistClick) }
                             }
                             if (artists.loadState.append is LoadState.Loading) {
                                 item { LoadingRow() }
@@ -96,14 +103,17 @@ fun ArtistsScreen(
                         }
                     }
                     else -> {
-                        LazyColumn(modifier = Modifier.fillMaxSize()) {
-                            pagingItems(artists, key = { it.id }) { artist ->
-                                artist?.let { ArtistRow(it, onArtistClick) }
-                            }
-                            if (artists.loadState.append is LoadState.Loading) {
-                                item { LoadingRow() }
-                            }
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(
+                            count = artists.itemCount,
+                            key = { index -> artists[index]?.id }
+                        ) { index ->
+                            artists[index]?.let { ArtistRow(it, onArtistClick) }
                         }
+                        if (artists.loadState.append is LoadState.Loading) {
+                            item { LoadingRow() }
+                        }
+                    }
                     }
                 }
             }

--- a/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items as pagingItems
 import coil.compose.AsyncImage
 import com.wikiart.model.LayoutType
 
@@ -47,8 +46,11 @@ fun PaintingsScreen(
             when (layoutType) {
                 LayoutType.LIST -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        pagingItems(paintings, key = { it.id }) { painting ->
-                            painting?.let { PaintingColumnItem(it, onPaintingClick) }
+                        items(
+                            count = paintings.itemCount,
+                            key = { index -> paintings[index]?.id }
+                        ) { index ->
+                            paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
                             item { LoadingRow() }
@@ -62,8 +64,11 @@ fun PaintingsScreen(
                         state = state,
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        pagingItems(paintings, key = { it.id }) { painting ->
-                            painting?.let { PaintingGridItem(it, onPaintingClick) }
+                        items(
+                            count = paintings.itemCount,
+                            key = { index -> paintings[index]?.id }
+                        ) { index ->
+                            paintings[index]?.let { PaintingGridItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
                             item { LoadingRow() }
@@ -75,8 +80,11 @@ fun PaintingsScreen(
                         columns = GridCells.Fixed(2),
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        pagingItems(paintings, key = { it.id }) { painting ->
-                            painting?.let { PaintingSheetItem(it, onPaintingClick) }
+                        items(
+                            count = paintings.itemCount,
+                            key = { index -> paintings[index]?.id }
+                        ) { index ->
+                            paintings[index]?.let { PaintingSheetItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
                             item(span = { GridItemSpan(maxLineSpan) }) { LoadingRow() }
@@ -85,8 +93,11 @@ fun PaintingsScreen(
                 }
                 else -> {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        pagingItems(paintings, key = { it.id }) { painting ->
-                            painting?.let { PaintingColumnItem(it, onPaintingClick) }
+                        items(
+                            count = paintings.itemCount,
+                            key = { index -> paintings[index]?.id }
+                        ) { index ->
+                            paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
                         if (paintings.loadState.append is LoadState.Loading) {
                             item { LoadingRow() }


### PR DESCRIPTION
## Summary
- fix usage of Paging Compose in Artists, ArtistPaintings and Paintings screens
- replace removed `pagingItems` extension with built‑in `items()` APIs
- add missing `items` imports for lazy lists

## Testing
- `./gradlew -p . test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb05f6340832e9d56280e8ba66aa2