### PR TITLE
Fix missing Material3 theme resources

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation platform('androidx.compose:compose-bom:2024.05.00')
     implementation 'androidx.compose.material3:material3'
 


### PR DESCRIPTION
## Summary
- add Material Components dependency for Material3 styles

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530f932920832e96ff71a154a9bfad