### PR TITLE
Improve layout option visuals

### DIFF
--- a/android/app/src/main/java/com/wikiart/ComposeOptionsBottomSheet.kt
+++ b/android/app/src/main/java/com/wikiart/ComposeOptionsBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
@@ -20,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wikiart.model.LayoutType
@@ -76,12 +78,30 @@ fun <T : CategoryItem> OptionsBottomSheet(
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                RadioButton(selected = layout == LayoutType.LIST, onClick = { layout = LayoutType.LIST })
-                Text(text = "List")
-                RadioButton(selected = layout == LayoutType.COLUMN, onClick = { layout = LayoutType.COLUMN })
-                Text(text = "Grid")
-                RadioButton(selected = layout == LayoutType.SHEET, onClick = { layout = LayoutType.SHEET })
-                Text(text = "Sheet")
+                RadioButton(
+                    selected = layout == LayoutType.LIST,
+                    onClick = { layout = LayoutType.LIST }
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_layout_list),
+                    contentDescription = stringResource(R.string.layout_list)
+                )
+                RadioButton(
+                    selected = layout == LayoutType.COLUMN,
+                    onClick = { layout = LayoutType.COLUMN }
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_layout_grid),
+                    contentDescription = stringResource(R.string.layout_grid)
+                )
+                RadioButton(
+                    selected = layout == LayoutType.SHEET,
+                    onClick = { layout = LayoutType.SHEET }
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_layout_sheet),
+                    contentDescription = stringResource(R.string.layout_sheet)
+                )
             }
             Button(
                 onClick = {

--- a/android/app/src/main/res/drawable/ic_layout_grid.xml
+++ b/android/app/src/main/res/drawable/ic_layout_grid.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M14.67,5v6.5H9.33V5H14.67z M15.67,11.5H21V5h-5.33V11.5z M14.67,19v-6.5H9.33V19H14.67z M15.67,12.5V19H21v-6.5H15.67z M8.33,12.5H3V19h5.33V12.5z M8.33,11.5V5H3v6.5H8.33z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_layout_list.xml
+++ b/android/app/src/main/res/drawable/ic_layout_list.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M3,14h4v-4H3V14z M3,19h4v-4H3V19z M3,9h4V5H3V9z M8,14h13v-4H8V14z M8,19h13v-4H8V19z M8,5v4h13V5H8z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_layout_sheet.xml
+++ b/android/app/src/main/res/drawable/ic_layout_sheet.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M2 21h19v-3H2v3zM20 8H3c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h17c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1zM2 3v3h19V3H2z"/>
+</vector>

--- a/android/app/src/main/res/layout/bottom_sheet_options.xml
+++ b/android/app/src/main/res/layout/bottom_sheet_options.xml
@@ -21,19 +21,22 @@
             android:id="@+id/layoutList"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="List" />
+            android:drawableStart="@drawable/ic_layout_list"
+            android:text="@string/layout_list" />
 
         <RadioButton
             android:id="@+id/layoutGrid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Grid" />
+            android:drawableStart="@drawable/ic_layout_grid"
+            android:text="@string/layout_grid" />
 
         <RadioButton
             android:id="@+id/layoutSheet"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Sheet" />
+            android:drawableStart="@drawable/ic_layout_sheet"
+            android:text="@string/layout_sheet" />
     </RadioGroup>
 
     <Button

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -77,6 +77,9 @@
     <string name="birth_label">Born:</string>
     <string name="death_label">Died:</string>
     <string name="change_layout">Change layout</string>
+    <string name="layout_list">List layout</string>
+    <string name="layout_grid">Grid layout</string>
+    <string name="layout_sheet">Sheet layout</string>
 
     <!-- Transition name used for shared element animations -->
     <string name="transition_detail_image">detailImage</string>


### PR DESCRIPTION
## Summary
- use icons instead of text for layout selection in Compose bottom sheet
- show the same icons in the XML layout
- add strings and vector assets for new icons

## Testing
- `./android/gradlew -p android test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853100a3f58832e8f24c65b52536d39