### PR TITLE
Fix Compose item key handling

### DIFF
--- a/android/app/src/main/java/com/wikiart/ArtistPaintingsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistPaintingsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
@@ -52,7 +51,7 @@ fun ArtistPaintingsScreen(
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
                             items(
                                 count = paintings.itemCount,
-                                key = { index -> paintings[index]?.id }
+                                key = { index -> paintings[index]?.id ?: index }
                             ) { index ->
                                 paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                             }
@@ -68,7 +67,7 @@ fun ArtistPaintingsScreen(
                         ) {
                             items(
                                 count = paintings.itemCount,
-                                key = { index -> paintings[index]?.id }
+                                key = { index -> paintings[index]?.id ?: index }
                             ) { index ->
                                 paintings[index]?.let { PaintingGridItem(it, onPaintingClick) }
                             }
@@ -82,7 +81,7 @@ fun ArtistPaintingsScreen(
                             columns = GridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            gridItems(paintings.itemCount) { index ->
+                            androidx.compose.foundation.lazy.grid.items(paintings.itemCount) { index ->
                                 paintings[index]?.let { PaintingSheetItem(it, onPaintingClick) }
                             }
                             if (paintings.loadState.append is LoadState.Loading) {
@@ -94,7 +93,7 @@ fun ArtistPaintingsScreen(
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(
                             count = paintings.itemCount,
-                            key = { index -> paintings[index]?.id }
+                            key = { index -> paintings[index]?.id ?: index }
                         ) { index ->
                             paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }

--- a/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/ArtistsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
@@ -64,7 +63,7 @@ fun ArtistsScreen(
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
                             items(
                                 count = artists.itemCount,
-                                key = { index -> artists[index]?.id }
+                                key = { index -> artists[index]?.id ?: index }
                             ) { index ->
                                 artists[index]?.let { ArtistRow(it, onArtistClick) }
                             }
@@ -80,7 +79,7 @@ fun ArtistsScreen(
                         ) {
                             items(
                                 count = artists.itemCount,
-                                key = { index -> artists[index]?.id }
+                                key = { index -> artists[index]?.id ?: index }
                             ) { index ->
                                 artists[index]?.let { ArtistGridItem(it, onArtistClick) }
                             }
@@ -94,7 +93,7 @@ fun ArtistsScreen(
                             columns = GridCells.Fixed(2),
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            gridItems(artists.itemCount) { index ->
+                            androidx.compose.foundation.lazy.grid.items(artists.itemCount) { index ->
                                 artists[index]?.let { ArtistSheetItem(it, onArtistClick) }
                             }
                             if (artists.loadState.append is LoadState.Loading) {
@@ -106,7 +105,7 @@ fun ArtistsScreen(
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(
                             count = artists.itemCount,
-                            key = { index -> artists[index]?.id }
+                            key = { index -> artists[index]?.id ?: index }
                         ) { index ->
                             artists[index]?.let { ArtistRow(it, onArtistClick) }
                         }

--- a/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
+++ b/android/app/src/main/java/com/wikiart/PaintingsScreen.kt
@@ -48,7 +48,7 @@ fun PaintingsScreen(
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(
                             count = paintings.itemCount,
-                            key = { index -> paintings[index]?.id }
+                            key = { index -> paintings[index]?.id ?: index }
                         ) { index ->
                             paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }
@@ -66,7 +66,7 @@ fun PaintingsScreen(
                     ) {
                         items(
                             count = paintings.itemCount,
-                            key = { index -> paintings[index]?.id }
+                            key = { index -> paintings[index]?.id ?: index }
                         ) { index ->
                             paintings[index]?.let { PaintingGridItem(it, onPaintingClick) }
                         }
@@ -82,7 +82,7 @@ fun PaintingsScreen(
                     ) {
                         items(
                             count = paintings.itemCount,
-                            key = { index -> paintings[index]?.id }
+                            key = { index -> paintings[index]?.id ?: index }
                         ) { index ->
                             paintings[index]?.let { PaintingSheetItem(it, onPaintingClick) }
                         }
@@ -95,7 +95,7 @@ fun PaintingsScreen(
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(
                             count = paintings.itemCount,
-                            key = { index -> paintings[index]?.id }
+                            key = { index -> paintings[index]?.id ?: index }
                         ) { index ->
                             paintings[index]?.let { PaintingColumnItem(it, onPaintingClick) }
                         }


### PR DESCRIPTION
## Summary
- ensure keys for Lazy collections are non-null
- use fully qualified `items()` for grid

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531176c89c832e950794939ec6c2f5