### PR TITLE
Fix Compose build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.12.0'
-    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation platform('androidx.compose:compose-bom:2024.06.00')
     implementation 'androidx.compose.material3:material3'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'


### PR DESCRIPTION
## Summary
- update Compose BOM for compatibility with modern Compose APIs

## Testing
- `./gradlew assembleDebug -x lint -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853136d0ca0832eb6d0641fe9b0934e