### PR TITLE
Add painting list screen

### DIFF
--- a/WikiArt/app/build.gradle.kts
+++ b/WikiArt/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.retrofit2)
     implementation(libs.converter.moshi)
+    implementation(libs.coil)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -15,6 +15,14 @@ interface WikiArtService {
         @Query("json") json: Int = 2
     ): PaintingList
 
+    @GET("/{lang}")
+    suspend fun paintingsByCategory(
+        @Path("lang") language: String,
+        @Query("param") param: String,
+        @Query("page") page: Int,
+        @Query("json") json: Int = 2
+    ): PaintingList
+
     @GET("/{lang}/api/2/Painting")
     suspend fun paintingDetails(
         @Path("lang") language: String,

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingCategory.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingCategory.kt
@@ -1,0 +1,9 @@
+package com.example.wikiart.model
+
+import com.example.wikiart.R
+
+enum class PaintingCategory(val param: String, val titleRes: Int) {
+    FEATURED("featured", R.string.category_featured),
+    POPULAR("popular", R.string.category_popular),
+    HIGH_RES("high_resolution", R.string.category_high_res)
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -1,0 +1,59 @@
+package com.example.wikiart.ui.paintings
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.example.wikiart.R
+import com.example.wikiart.model.Painting
+
+class PaintingAdapter(private var layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>() {
+
+    enum class Layout { LIST, GRID, SHEET }
+
+    private val items = mutableListOf<Painting>()
+
+    fun submitList(data: List<Painting>) {
+        items.clear()
+        items.addAll(data)
+        notifyDataSetChanged()
+    }
+
+    fun setLayout(l: Layout) {
+        layout = l
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int = layout.ordinal
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val res = when(layout) {
+            Layout.LIST -> R.layout.item_painting_list
+            Layout.GRID -> R.layout.item_painting_grid
+            Layout.SHEET -> R.layout.item_painting_sheet
+        }
+        val view = LayoutInflater.from(parent.context).inflate(res, parent, false)
+        return VH(view, layout)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class VH(view: View, private val layout: Layout) : RecyclerView.ViewHolder(view) {
+        private val image: ImageView = view.findViewById(R.id.paintingImage)
+        private val title: TextView? = view.findViewById(R.id.paintingTitle)
+        private val artist: TextView? = view.findViewById(R.id.paintingArtist)
+
+        fun bind(p: Painting) {
+            image.load(p.imageUrl())
+            title?.text = p.title
+            artist?.text = p.artistName
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -1,0 +1,95 @@
+package com.example.wikiart.ui.paintings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ImageButton
+import android.widget.Spinner
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.wikiart.R
+import com.example.wikiart.databinding.FragmentPaintingListBinding
+import com.example.wikiart.model.PaintingCategory
+
+class PaintingListFragment : Fragment() {
+
+    private var _binding: FragmentPaintingListBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: PaintingListViewModel by viewModels()
+    private lateinit var adapter: PaintingAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPaintingListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        adapter = PaintingAdapter(PaintingAdapter.Layout.LIST)
+        binding.paintingRecyclerView.adapter = adapter
+        binding.paintingRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        setupCategorySpinner(binding.categorySpinner)
+        binding.layoutButton.setOnClickListener { toggleLayout() }
+
+        viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
+
+        viewModel.loadNext()
+
+        binding.paintingRecyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                val manager = recyclerView.layoutManager as LinearLayoutManager
+                val lastVisible = manager.findLastVisibleItemPosition()
+                if (lastVisible >= adapter.itemCount - 5) {
+                    viewModel.loadNext()
+                }
+            }
+        })
+    }
+
+    private fun setupCategorySpinner(spinner: Spinner) {
+        val items = PaintingCategory.values().map { getString(it.titleRes) }
+        spinner.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_dropdown_item, items)
+        spinner.setSelection(PaintingCategory.values().indexOf(viewModel.category))
+        spinner.setOnItemSelectedListener(object : android.widget.AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: android.widget.AdapterView<*>, view: View?, position: Int, id: Long) {
+                val cat = PaintingCategory.values()[position]
+                viewModel.setCategory(cat)
+            }
+
+            override fun onNothingSelected(parent: android.widget.AdapterView<*>) {}
+        })
+    }
+
+    private fun toggleLayout() {
+        val next = when(adapter.layout) {
+            PaintingAdapter.Layout.LIST -> PaintingAdapter.Layout.GRID
+            PaintingAdapter.Layout.GRID -> PaintingAdapter.Layout.SHEET
+            PaintingAdapter.Layout.SHEET -> PaintingAdapter.Layout.LIST
+        }
+        adapter.setLayout(next)
+        val manager = when(next) {
+            PaintingAdapter.Layout.LIST -> LinearLayoutManager(requireContext())
+            PaintingAdapter.Layout.GRID -> GridLayoutManager(requireContext(), 2)
+            PaintingAdapter.Layout.SHEET -> GridLayoutManager(requireContext(), 2)
+        }
+        binding.paintingRecyclerView.layoutManager = manager
+        binding.paintingRecyclerView.scrollToPosition(0)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.wikiart.ui.paintings
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.ApiClient
+import com.example.wikiart.model.Painting
+import com.example.wikiart.model.PaintingCategory
+import kotlinx.coroutines.launch
+
+class PaintingListViewModel : ViewModel() {
+    private val _paintings = MutableLiveData<List<Painting>>(emptyList())
+    val paintings: LiveData<List<Painting>> = _paintings
+
+    private var page = 1
+    private var loading = false
+    var category: PaintingCategory = PaintingCategory.POPULAR
+        private set
+
+    fun loadNext() {
+        if (loading) return
+        loading = true
+        viewModelScope.launch {
+            try {
+                val result = ApiClient.service.paintingsByCategory(
+                    language = "en",
+                    param = category.param,
+                    page = page
+                )
+                _paintings.value = _paintings.value!! + result.Paintings
+                page++
+            } catch (_: Exception) {
+            }
+            loading = false
+        }
+    }
+
+    fun setCategory(cat: PaintingCategory) {
+        if (category == cat) return
+        category = cat
+        page = 1
+        _paintings.value = emptyList()
+        loadNext()
+    }
+}

--- a/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp">
+
+        <Spinner
+            android:id="@+id/categorySpinner"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content" />
+
+        <ImageButton
+            android:id="@+id/layoutButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_dialog_dialer" />
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/paintingRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/WikiArt/app/src/main/res/layout/item_painting_grid.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_grid.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="4dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true" />
+
+    <TextView
+        android:id="@+id/paintingTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/WikiArt/app/src/main/res/layout/item_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_list.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true" />
+
+    <TextView
+        android:id="@+id/paintingTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/paintingArtist"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/paintingImage"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:adjustViewBounds="true" />

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -7,9 +7,9 @@
 
     <fragment
         android:id="@+id/navigation_home"
-        android:name="com.example.wikiart.ui.home.HomeFragment"
+        android:name="com.example.wikiart.ui.paintings.PaintingListFragment"
         android:label="@string/title_home"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_painting_list" />
 
     <fragment
         android:id="@+id/navigation_dashboard"

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="title_home">Home</string>
     <string name="title_dashboard">Dashboard</string>
     <string name="title_notifications">Notifications</string>
+    <string name="category_featured">Featured</string>
+    <string name="category_popular">Popular</string>
+    <string name="category_high_res">High Resolution</string>
 </resources>

--- a/WikiArt/gradle/libs.versions.toml
+++ b/WikiArt/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lifecycleViewmodelKtx = "2.9.1"
 navigationFragmentKtx = "2.6.0"
 navigationUiKtx = "2.6.0"
 retrofit = "2.11.0"
+coil = "2.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navi
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
+coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- implement `PaintingCategory` enum with constants for the API
- add Retrofit call for generic category fetch
- integrate Coil dependency
- create adapter and fragment for displaying painting lists
- wire the new fragment as the Home screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685325eeb544832e8e81c1b1532ccf3f