### PR TITLE
Fix PaintingAdapter layout visibility

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -10,7 +10,10 @@ import coil.load
 import com.example.wikiart.R
 import com.example.wikiart.model.Painting
 
-class PaintingAdapter(private var layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>() {
+class PaintingAdapter(layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>() {
+
+    var layout: Layout = layout
+        private set
 
     enum class Layout { LIST, GRID, SHEET }
 


### PR DESCRIPTION
## Summary
- expose a read-only `layout` property in `PaintingAdapter` so the fragment can read it

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532823a128832e88470ca79cdc10b8