### PR TITLE
Update bottom navigation

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
@@ -26,7 +26,10 @@ class MainActivity : AppCompatActivity() {
         // menu should be considered as top level destinations.
         val appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.navigation_home, R.id.navigation_dashboard, R.id.navigation_notifications
+                R.id.navigation_paintings,
+                R.id.navigation_artists,
+                R.id.navigation_search,
+                R.id.navigation_support
             )
         )
         setupActionBarWithNavController(navController, appBarConfiguration)

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
@@ -1,0 +1,42 @@
+package com.example.wikiart.ui.artists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.example.wikiart.databinding.FragmentArtistsBinding
+
+class ArtistsFragment : Fragment() {
+
+    private var _binding: FragmentArtistsBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val artistsViewModel =
+            ViewModelProvider(this).get(ArtistsViewModel::class.java)
+
+        _binding = FragmentArtistsBinding.inflate(inflater, container, false)
+        val root: View = binding.root
+
+        val textView: TextView = binding.textArtists
+        artistsViewModel.text.observe(viewLifecycleOwner) {
+            textView.text = it
+        }
+        return root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.wikiart.ui.artists
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class ArtistsViewModel : ViewModel() {
+
+    private val _text = MutableLiveData<String>().apply {
+        value = "This is artists Fragment"
+    }
+    val text: LiveData<String> = _text
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
@@ -1,0 +1,42 @@
+package com.example.wikiart.ui.search
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.example.wikiart.databinding.FragmentSearchBinding
+
+class SearchFragment : Fragment() {
+
+    private var _binding: FragmentSearchBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val searchViewModel =
+            ViewModelProvider(this).get(SearchViewModel::class.java)
+
+        _binding = FragmentSearchBinding.inflate(inflater, container, false)
+        val root: View = binding.root
+
+        val textView: TextView = binding.textSearch
+        searchViewModel.text.observe(viewLifecycleOwner) {
+            textView.text = it
+        }
+        return root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.wikiart.ui.search
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class SearchViewModel : ViewModel() {
+
+    private val _text = MutableLiveData<String>().apply {
+        value = "This is search Fragment"
+    }
+    val text: LiveData<String> = _text
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/support/SupportFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/support/SupportFragment.kt
@@ -1,0 +1,42 @@
+package com.example.wikiart.ui.support
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.example.wikiart.databinding.FragmentSupportBinding
+
+class SupportFragment : Fragment() {
+
+    private var _binding: FragmentSupportBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val supportViewModel =
+            ViewModelProvider(this).get(SupportViewModel::class.java)
+
+        _binding = FragmentSupportBinding.inflate(inflater, container, false)
+        val root: View = binding.root
+
+        val textView: TextView = binding.textSupport
+        supportViewModel.text.observe(viewLifecycleOwner) {
+            textView.text = it
+        }
+        return root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/support/SupportViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/support/SupportViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.wikiart.ui.support
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class SupportViewModel : ViewModel() {
+
+    private val _text = MutableLiveData<String>().apply {
+        value = "This is support Fragment"
+    }
+    val text: LiveData<String> = _text
+}

--- a/WikiArt/app/src/main/res/drawable/baseline_help_24.xml
+++ b/WikiArt/app/src/main/res/drawable/baseline_help_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,19h-2v-2h2v2zM15.07,11.25l-0.9,0.92C13.45,12.9 13,13.5 13,15h-2v-0.5c0,-1.1 0.45,-2.1 1.17,-2.83l1.24,-1.26c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2L8,9c0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,0.88 -0.36,1.68 -0.93,2.25z"/>
+</vector>

--- a/WikiArt/app/src/main/res/drawable/baseline_palette_24.xml
+++ b/WikiArt/app/src/main/res/drawable/baseline_palette_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.49,2 2,6.49 2,12s4.49,10 10,10c1.38,0 2.5,-1.12 2.5,-2.5c0,-0.61 -0.23,-1.2 -0.64,-1.67c-0.08,-0.1 -0.13,-0.21 -0.13,-0.33c0,-0.28 0.22,-0.5 0.5,-0.5H16c3.31,0 6,-2.69 6,-6C22,6.04 17.51,2 12,2zM17.5,13c-0.83,0 -1.5,-0.67 -1.5,-1.5c0,-0.83 0.67,-1.5 1.5,-1.5s1.5,0.67 1.5,1.5C19,12.33 18.33,13 17.5,13zM14.5,9C13.67,9 13,8.33 13,7.5C13,6.67 13.67,6 14.5,6S16,6.67 16,7.5C16,8.33 15.33,9 14.5,9zM5,11.5C5,10.67 5.67,10 6.5,10S8,10.67 8,11.5C8,12.33 7.33,13 6.5,13S5,12.33 5,11.5zM11,7.5C11,8.33 10.33,9 9.5,9S8,8.33 8,7.5C8,6.67 8.67,6 9.5,6S11,6.67 11,7.5z"/>
+</vector>

--- a/WikiArt/app/src/main/res/drawable/baseline_person_24.xml
+++ b/WikiArt/app/src/main/res/drawable/baseline_person_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/WikiArt/app/src/main/res/drawable/baseline_search_24.xml
+++ b/WikiArt/app/src/main/res/drawable/baseline_search_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/WikiArt/app/src/main/res/layout/fragment_artists.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artists.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.artists.ArtistsFragment">
+
+    <TextView
+        android:id="@+id/text_artists"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WikiArt/app/src/main/res/layout/fragment_search.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.search.SearchFragment">
+
+    <TextView
+        android:id="@+id/text_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WikiArt/app/src/main/res/layout/fragment_support.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_support.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.support.SupportFragment">
+
+    <TextView
+        android:id="@+id/text_support"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WikiArt/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/WikiArt/app/src/main/res/menu/bottom_nav_menu.xml
@@ -2,18 +2,23 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/navigation_home"
-        android:icon="@drawable/ic_home_black_24dp"
-        android:title="@string/title_home" />
+        android:id="@+id/navigation_paintings"
+        android:icon="@drawable/baseline_palette_24"
+        android:title="@string/title_paintings" />
 
     <item
-        android:id="@+id/navigation_dashboard"
-        android:icon="@drawable/ic_dashboard_black_24dp"
-        android:title="@string/title_dashboard" />
+        android:id="@+id/navigation_artists"
+        android:icon="@drawable/baseline_person_24"
+        android:title="@string/title_artists" />
 
     <item
-        android:id="@+id/navigation_notifications"
-        android:icon="@drawable/ic_notifications_black_24dp"
-        android:title="@string/title_notifications" />
+        android:id="@+id/navigation_search"
+        android:icon="@drawable/baseline_search_24"
+        android:title="@string/title_search" />
+
+    <item
+        android:id="@+id/navigation_support"
+        android:icon="@drawable/baseline_help_24"
+        android:title="@string/title_support" />
 
 </menu>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -3,23 +3,29 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mobile_navigation"
-    app:startDestination="@+id/navigation_home">
+    app:startDestination="@+id/navigation_paintings">
 
     <fragment
-        android:id="@+id/navigation_home"
+        android:id="@+id/navigation_paintings"
         android:name="com.example.wikiart.ui.paintings.PaintingListFragment"
-        android:label="@string/title_home"
+        android:label="@string/title_paintings"
         tools:layout="@layout/fragment_painting_list" />
 
     <fragment
-        android:id="@+id/navigation_dashboard"
-        android:name="com.example.wikiart.ui.dashboard.DashboardFragment"
-        android:label="@string/title_dashboard"
-        tools:layout="@layout/fragment_dashboard" />
+        android:id="@+id/navigation_artists"
+        android:name="com.example.wikiart.ui.artists.ArtistsFragment"
+        android:label="@string/title_artists"
+        tools:layout="@layout/fragment_artists" />
 
     <fragment
-        android:id="@+id/navigation_notifications"
-        android:name="com.example.wikiart.ui.notifications.NotificationsFragment"
-        android:label="@string/title_notifications"
-        tools:layout="@layout/fragment_notifications" />
+        android:id="@+id/navigation_search"
+        android:name="com.example.wikiart.ui.search.SearchFragment"
+        android:label="@string/title_search"
+        tools:layout="@layout/fragment_search" />
+
+    <fragment
+        android:id="@+id/navigation_support"
+        android:name="com.example.wikiart.ui.support.SupportFragment"
+        android:label="@string/title_support"
+        tools:layout="@layout/fragment_support" />
 </navigation>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -1,8 +1,9 @@
 <resources>
     <string name="app_name">WikiArt</string>
-    <string name="title_home">Home</string>
-    <string name="title_dashboard">Dashboard</string>
-    <string name="title_notifications">Notifications</string>
+    <string name="title_paintings">Paintings</string>
+    <string name="title_artists">Artists</string>
+    <string name="title_search">Search</string>
+    <string name="title_support">Support</string>
     <string name="category_featured">Featured</string>
     <string name="category_popular">Popular</string>
     <string name="category_high_res">High Resolution</string>


### PR DESCRIPTION
## Summary
- expand bottom navigation menu to support Paintings, Artists, Search and Support
- wire up new fragments for Artists, Search and Support
- update navigation graph and main activity
- provide icons and titles for the new destinations

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532b1131d8832ebfe5556deb811d16