### PR TITLE
Add loading indicator to painting list

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -46,6 +46,9 @@ class PaintingListFragment : Fragment() {
         binding.paintingRecyclerView.layoutManager = layoutManagerFor(viewModel.layout)
 
         viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
+        viewModel.loading.observe(viewLifecycleOwner) { isLoading ->
+            binding.loadingProgressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+        }
 
         viewModel.loadNext()
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
@@ -13,21 +13,23 @@ class PaintingListViewModel : ViewModel() {
     private val _paintings = MutableLiveData<List<Painting>>(emptyList())
     val paintings: LiveData<List<Painting>> = _paintings
 
+    private val _loading = MutableLiveData(false)
+    val loading: LiveData<Boolean> = _loading
+
     private var page = 1
-    private var loading = false
     var category: PaintingCategory = PaintingCategory.POPULAR
         private set
     var layout: PaintingAdapter.Layout = PaintingAdapter.Layout.LIST
         private set
 
     fun loadNext() {
-        if (loading) return
-        loading = true
+        if (_loading.value == true) return
+        _loading.value = true
         viewModelScope.launch {
             try {
                 if (category == PaintingCategory.FAVORITES) {
                     // TODO: load favourites from local storage when implemented
-                    loading = false
+                    _loading.value = false
                     return@launch
                 }
 
@@ -40,7 +42,7 @@ class PaintingListViewModel : ViewModel() {
                 page++
             } catch (_: Exception) {
             }
-            loading = false
+            _loading.value = false
         }
     }
 

--- a/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/paintingRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</LinearLayout>
+    <ProgressBar
+        android:id="@+id/loadingProgressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- show a `ProgressBar` over the painting list
- expose loading `LiveData` from `PaintingListViewModel`
- observe loading state in `PaintingListFragment` to toggle the indicator

## Testing
- `./WikiArt/gradlew -p WikiArt test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533bebfb74832e8f30b6745892bbf9