### PR TITLE
Add category spinner and fix popular paintings

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -12,6 +12,8 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import android.widget.ArrayAdapter
+import android.widget.AdapterView
 import android.widget.Toast
 import com.example.wikiart.R
 import com.example.wikiart.databinding.FragmentPaintingListBinding
@@ -45,6 +47,21 @@ class PaintingListFragment : Fragment() {
         adapter = PaintingAdapter(viewModel.layout)
         binding.paintingRecyclerView.adapter = adapter
         binding.paintingRecyclerView.layoutManager = layoutManagerFor(viewModel.layout)
+
+        val categories = PaintingCategory.values()
+        val titles = categories.map { getString(it.titleRes) }
+        binding.categorySelector.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_dropdown_item, titles)
+        binding.categorySelector.setSelection(categories.indexOf(viewModel.category))
+        binding.categorySelector.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                val selected = categories[position]
+                if (selected != viewModel.category) {
+                    viewModel.setCategory(selected)
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
 
         binding.categoryButton.setOnClickListener { openOptions() }
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
@@ -37,11 +37,18 @@ class PaintingListViewModel : ViewModel() {
                     return@launch
                 }
 
-                val result = ApiClient.service.paintingsByCategory(
-                    language = "en",
-                    param = category.param,
-                    page = page
-                )
+                val result = if (category == PaintingCategory.POPULAR) {
+                    ApiClient.service.popularPaintings(
+                        language = "en",
+                        page = page
+                    )
+                } else {
+                    ApiClient.service.paintingsByCategory(
+                        language = "en",
+                        param = category.param,
+                        page = page
+                    )
+                }
                 _paintings.value = _paintings.value!! + result.Paintings
                 page++
             } catch (e: Exception) {

--- a/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
@@ -16,6 +16,13 @@
         android:layout_gravity="center"
         android:visibility="gone" />
 
+    <Spinner
+        android:id="@+id/categorySelector"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_margin="16dp" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/categoryButton"
         android:layout_width="wrap_content"

--- a/WikiArt/app/src/test/java/com/example/wikiart/ui/paintings/PaintingListViewModelTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/ui/paintings/PaintingListViewModelTest.kt
@@ -16,7 +16,20 @@ class PaintingListViewModelTest {
     private class FakeService : WikiArtService {
         var lastPageRequested = 0
         override suspend fun popularPaintings(language: String, page: Int, json: Int): PaintingList {
-            throw NotImplementedError()
+            lastPageRequested = page
+            val p = Painting(
+                id = "popular_$page",
+                title = "Title$page",
+                year = "",
+                width = 0,
+                height = 0,
+                artistName = "Artist",
+                image = "url",
+                paintingUrl = "",
+                artistUrl = null,
+                flags = 0
+            )
+            return PaintingList(listOf(p), 1, 1)
         }
         override suspend fun paintingsByCategory(language: String, param: String, page: Int, json: Int): PaintingList {
             lastPageRequested = page


### PR DESCRIPTION
## Summary
- add dropdown on Painting list screen for choosing categories
- use proper popular endpoint in `PaintingListViewModel`
- update unit test fake service to support popular endpoint

## Testing
- `./WikiArt/gradlew -p WikiArt test --console=plain --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538b726110832e89261fbd670a7b43