### PR TITLE
Add painting detail screen with related artworks

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
@@ -1,0 +1,11 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.Painting
+
+class PaintingDetailsRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun getPainting(id: String, language: String = "en"): Painting {
+        return service.paintingDetails(language, id)
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/RelatedPaintingsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/RelatedPaintingsRepository.kt
@@ -1,0 +1,11 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.Painting
+
+class RelatedPaintingsRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun getRelated(path: String): List<Painting> {
+        return service.relatedPaintings(path).Paintings
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -1,11 +1,11 @@
 package com.example.wikiart.api
 
-import com.example.wikiart.model.Artist
 import com.example.wikiart.model.Painting
 import com.example.wikiart.model.PaintingList
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Url
 
 interface WikiArtService {
     @GET("/{lang}/popular-paintings/alltime")
@@ -28,4 +28,10 @@ interface WikiArtService {
         @Path("lang") language: String,
         @Query("id") id: String
     ): Painting
+
+    @GET
+    suspend fun relatedPaintings(
+        @Url path: String,
+        @Query("json") json: Int = 2
+    ): PaintingList
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -10,7 +10,7 @@ import coil.load
 import com.example.wikiart.R
 import com.example.wikiart.model.Painting
 
-class PaintingAdapter(layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>() {
+class PaintingAdapter(layout: Layout, private val listener: ((Painting) -> Unit)? = null) : RecyclerView.Adapter<PaintingAdapter.VH>() {
 
     var layout: Layout = layout
         private set
@@ -43,7 +43,7 @@ class PaintingAdapter(layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>
     }
 
     override fun onBindViewHolder(holder: VH, position: Int) {
-        holder.bind(items[position])
+        holder.bind(items[position], listener)
     }
 
     override fun getItemCount(): Int = items.size
@@ -53,10 +53,11 @@ class PaintingAdapter(layout: Layout) : RecyclerView.Adapter<PaintingAdapter.VH>
         private val title: TextView? = view.findViewById(R.id.paintingTitle)
         private val artist: TextView? = view.findViewById(R.id.paintingArtist)
 
-        fun bind(p: Painting) {
+        fun bind(p: Painting, listener: ((Painting) -> Unit)?) {
             image.load(p.imageUrl())
             title?.text = p.title
             artist?.text = p.artistName
+            itemView.setOnClickListener { listener?.invoke(p) }
         }
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
@@ -1,0 +1,73 @@
+package com.example.wikiart.ui.paintings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import coil.load
+import com.example.wikiart.R
+import com.example.wikiart.databinding.FragmentPaintingDetailBinding
+
+class PaintingDetailFragment : Fragment() {
+
+    private var _binding: FragmentPaintingDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: PaintingDetailViewModel by viewModels {
+        PaintingDetailViewModel.Factory(requireArguments().getString(ARG_PAINTING_ID)!!)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPaintingDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val relatedAdapter = PaintingAdapter(PaintingAdapter.Layout.GRID) { painting ->
+            val bundle = Bundle().apply { putString(ARG_PAINTING_ID, painting.id) }
+            findNavController().navigate(R.id.action_paintingDetailFragment_self, bundle)
+        }
+        binding.relatedRecyclerView.adapter = relatedAdapter
+        binding.relatedRecyclerView.layoutManager = GridLayoutManager(requireContext(), 2)
+
+        viewModel.painting.observe(viewLifecycleOwner) { painting ->
+            painting?.let {
+                binding.paintingImage.load(it.imageUrl())
+                binding.paintingTitle.text = it.title
+                binding.paintingArtist.text = it.artistName
+            }
+        }
+
+        viewModel.related.observe(viewLifecycleOwner) {
+            relatedAdapter.submitList(it)
+        }
+
+        viewModel.loading.observe(viewLifecycleOwner) {
+            binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
+        }
+
+        // Buttons currently have no functionality
+        binding.favoriteButton.setOnClickListener { }
+        binding.shareButton.setOnClickListener { }
+        binding.buyButton.setOnClickListener { }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_PAINTING_ID = "painting_id"
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
@@ -1,0 +1,55 @@
+package com.example.wikiart.ui.paintings
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.PaintingDetailsRepository
+import com.example.wikiart.api.RelatedPaintingsRepository
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.launch
+
+class PaintingDetailViewModel(
+    private val paintingId: String,
+    private val detailsRepository: PaintingDetailsRepository = PaintingDetailsRepository(),
+    private val relatedRepository: RelatedPaintingsRepository = RelatedPaintingsRepository()
+) : ViewModel() {
+
+    private val _painting = MutableLiveData<Painting?>()
+    val painting: LiveData<Painting?> = _painting
+
+    private val _related = MutableLiveData<List<Painting>>(emptyList())
+    val related: LiveData<List<Painting>> = _related
+
+    private val _loading = MutableLiveData(false)
+    val loading: LiveData<Boolean> = _loading
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _loading.value = true
+            try {
+                val details = detailsRepository.getPainting(paintingId)
+                _painting.value = details
+                val rel = relatedRepository.getRelated(details.paintingUrl)
+                _related.value = rel
+            } catch (_: Exception) {
+            }
+            _loading.value = false
+        }
+    }
+
+    class Factory(private val paintingId: String) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(PaintingDetailViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return PaintingDetailViewModel(paintingId) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -18,6 +18,7 @@ import android.widget.Toast
 import com.example.wikiart.R
 import com.example.wikiart.databinding.FragmentPaintingListBinding
 import com.example.wikiart.model.PaintingCategory
+import androidx.navigation.fragment.findNavController
 
 class PaintingListFragment : Fragment() {
 
@@ -44,7 +45,10 @@ class PaintingListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = PaintingAdapter(viewModel.layout)
+        adapter = PaintingAdapter(viewModel.layout) { painting ->
+            val bundle = Bundle().apply { putString(PaintingDetailFragment.ARG_PAINTING_ID, painting.id) }
+            findNavController().navigate(R.id.action_paintingListFragment_to_paintingDetailFragment, bundle)
+        }
         binding.paintingRecyclerView.adapter = adapter
         binding.paintingRecyclerView.layoutManager = layoutManagerFor(viewModel.layout)
 

--- a/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/paintingImage"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:scaleType="centerCrop" />
+
+            <TextView
+                android:id="@+id/paintingTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceHeadline6"
+                android:padding="16dp" />
+
+            <TextView
+                android:id="@+id/paintingArtist"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="16dp">
+
+                <Button
+                    android:id="@+id/favoriteButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Favorite" />
+
+                <Button
+                    android:id="@+id/shareButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Share"
+                    android:layout_marginStart="8dp" />
+
+                <Button
+                    android:id="@+id/buyButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Buy"
+                    android:layout_marginStart="8dp" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Related artworks"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/relatedRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:layout_margin="8dp" />
+        </LinearLayout>
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -9,7 +9,11 @@
         android:id="@+id/navigation_paintings"
         android:name="com.example.wikiart.ui.paintings.PaintingListFragment"
         android:label="@string/title_paintings"
-        tools:layout="@layout/fragment_painting_list" />
+        tools:layout="@layout/fragment_painting_list" >
+        <action
+            android:id="@+id/action_paintingListFragment_to_paintingDetailFragment"
+            app:destination="@id/paintingDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_artists"
@@ -28,4 +32,14 @@
         android:name="com.example.wikiart.ui.support.SupportFragment"
         android:label="@string/title_support"
         tools:layout="@layout/fragment_support" />
+
+    <fragment
+        android:id="@+id/paintingDetailFragment"
+        android:name="com.example.wikiart.ui.paintings.PaintingDetailFragment"
+        android:label="@string/title_painting_detail"
+        tools:layout="@layout/fragment_painting_detail" >
+        <action
+            android:id="@+id/action_paintingDetailFragment_self"
+            app:destination="@id/paintingDetailFragment" />
+    </fragment>
 </navigation>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="layout_grid">Grid</string>
     <string name="layout_sheet">Sheet</string>
     <string name="action_options">Options</string>
+    <string name="title_painting_detail">Painting</string>
 </resources>


### PR DESCRIPTION
## Summary
- add PaintingDetailFragment with favorite/share/buy buttons and related artworks list
- fetch painting details and related paintings via new repositories
- enable clicking paintings to navigate to details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f17e12b4832eac3a874ac389a723