### PR TITLE
Add artist detail screen with biography and works

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistDetailsRepository.kt
@@ -1,0 +1,18 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.ArtistDetails
+import com.example.wikiart.model.Painting
+
+class ArtistDetailsRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun getDetails(path: String): ArtistDetails {
+        return service.artistDetails(path)
+    }
+
+    suspend fun getPaintings(path: String): List<Painting> {
+        // WikiArt API uses "/mode/featured" to list well known paintings for an artist
+        val list = service.artistPaintings("$path/mode/featured")
+        return list.Paintings
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -3,6 +3,7 @@ package com.example.wikiart.api
 import com.example.wikiart.model.Painting
 import com.example.wikiart.model.PaintingList
 import com.example.wikiart.model.ArtistList
+import com.example.wikiart.model.ArtistDetails
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -34,6 +35,19 @@ interface WikiArtService {
     suspend fun relatedPaintings(
         @Url path: String,
         @Query("json") json: Int = 2,
+    ): PaintingList
+
+    @GET
+    suspend fun artistDetails(
+        @Url path: String,
+        @Query("json") json: Int = 2,
+    ): ArtistDetails
+
+    @GET
+    suspend fun artistPaintings(
+        @Url path: String,
+        @Query("json") json: Int = 2,
+        @Query("page") page: Int = 1,
     ): PaintingList
 
     @GET("/{lang}/App/Search/{category}")

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistDetails.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistDetails.kt
@@ -1,0 +1,8 @@
+package com.example.wikiart.model
+
+/**
+ * Minimal representation of artist details returned by the WikiArt API.
+ */
+data class ArtistDetails(
+    val biography: String?
+)

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
@@ -1,0 +1,61 @@
+package com.example.wikiart.ui.artists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.wikiart.R
+import com.example.wikiart.databinding.FragmentArtistDetailBinding
+import com.example.wikiart.ui.paintings.PaintingAdapter
+import com.example.wikiart.ui.paintings.PaintingDetailFragment
+
+class ArtistDetailFragment : Fragment() {
+
+    private var _binding: FragmentArtistDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ArtistDetailViewModel by viewModels {
+        ArtistDetailViewModel.Factory(requireArguments().getString(ARG_ARTIST_PATH)!!)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentArtistDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val adapter = PaintingAdapter(PaintingAdapter.Layout.GRID) { painting ->
+            val bundle = Bundle().apply { putString(PaintingDetailFragment.ARG_PAINTING_ID, painting.id) }
+            findNavController().navigate(R.id.action_artistDetailFragment_to_paintingDetailFragment, bundle)
+        }
+        binding.paintingsRecyclerView.adapter = adapter
+        binding.paintingsRecyclerView.layoutManager = GridLayoutManager(requireContext(), 2)
+
+        viewModel.biography.observe(viewLifecycleOwner) {
+            binding.artistBiography.text = it ?: ""
+        }
+        viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
+        viewModel.loading.observe(viewLifecycleOwner) {
+            binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_ARTIST_PATH = "artist_path"
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailViewModel.kt
@@ -1,0 +1,53 @@
+package com.example.wikiart.ui.artists
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.ArtistDetailsRepository
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.launch
+
+class ArtistDetailViewModel(
+    private val artistPath: String,
+    private val repository: ArtistDetailsRepository = ArtistDetailsRepository(),
+) : ViewModel() {
+
+    private val _biography = MutableLiveData<String?>()
+    val biography: LiveData<String?> = _biography
+
+    private val _paintings = MutableLiveData<List<Painting>>(emptyList())
+    val paintings: LiveData<List<Painting>> = _paintings
+
+    private val _loading = MutableLiveData(false)
+    val loading: LiveData<Boolean> = _loading
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _loading.value = true
+            try {
+                val details = repository.getDetails(artistPath)
+                _biography.value = details.biography
+                val arts = repository.getPaintings(artistPath)
+                _paintings.value = arts
+            } catch (_: Exception) {
+            }
+            _loading.value = false
+        }
+    }
+
+    class Factory(private val artistPath: String) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ArtistDetailViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return ArtistDetailViewModel(artistPath) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
@@ -12,6 +12,7 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,7 +45,12 @@ class ArtistsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = ArtistAdapter(viewModel.layout)
+        adapter = ArtistAdapter(viewModel.layout) { artist ->
+            artist.artistUrl?.let {
+                val bundle = Bundle().apply { putString(ArtistDetailFragment.ARG_ARTIST_PATH, it) }
+                findNavController().navigate(R.id.action_navigation_artists_to_artistDetailFragment, bundle)
+            }
+        }
         binding.artistRecyclerView.adapter = adapter
         binding.artistRecyclerView.layoutManager = layoutManagerFor(viewModel.layout)
 

--- a/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/artistBiography"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:textAppearance="?attr/textAppearanceBody1" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Paintings"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/paintingsRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:nestedScrollingEnabled="false" />
+        </LinearLayout>
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -19,7 +19,11 @@
         android:id="@+id/navigation_artists"
         android:name="com.example.wikiart.ui.artists.ArtistsFragment"
         android:label="@string/title_artists"
-        tools:layout="@layout/fragment_artists" />
+        tools:layout="@layout/fragment_artists" >
+        <action
+            android:id="@+id/action_navigation_artists_to_artistDetailFragment"
+            app:destination="@id/artistDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_search"
@@ -40,6 +44,16 @@
         tools:layout="@layout/fragment_painting_detail" >
         <action
             android:id="@+id/action_paintingDetailFragment_self"
+            app:destination="@id/paintingDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/artistDetailFragment"
+        android:name="com.example.wikiart.ui.artists.ArtistDetailFragment"
+        android:label="@string/title_artist_detail"
+        tools:layout="@layout/fragment_artist_detail" >
+        <action
+            android:id="@+id/action_artistDetailFragment_to_paintingDetailFragment"
             app:destination="@id/paintingDetailFragment" />
     </fragment>
 </navigation>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="layout_sheet">Sheet</string>
     <string name="action_options">Options</string>
     <string name="title_painting_detail">Painting</string>
+    <string name="title_artist_detail">Artist</string>
 </resources>


### PR DESCRIPTION
## Summary
- add artist detail fragment and view model to show biography and paintings
- support artist details fetching through new repository and service endpoints
- wire up navigation from artist list to detail and onward to painting detail

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63d45e2c0832eafd6ec3f0d7713f9