### PR TITLE
Add artist detail screen with biography and paintings

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistDetailsRepository.kt
@@ -1,0 +1,16 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.ArtistDetails
+import com.example.wikiart.model.Painting
+
+class ArtistDetailsRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun getArtistDetails(id: String, language: String = "en"): ArtistDetails {
+        return service.artistDetails(language, id)
+    }
+
+    suspend fun getArtistPaintings(id: String, language: String = "en"): List<Painting> {
+        return service.paintingsByArtist(language, id).Paintings
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -3,6 +3,7 @@ package com.example.wikiart.api
 import com.example.wikiart.model.Painting
 import com.example.wikiart.model.PaintingList
 import com.example.wikiart.model.ArtistList
+import com.example.wikiart.model.ArtistDetails
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -44,4 +45,17 @@ interface WikiArtService {
         @Query("json") json: Int = 3,
         @Query("layout") layout: String = "new"
     ): ArtistList
+
+    @GET("/{lang}/api/2/Artist")
+    suspend fun artistDetails(
+        @Path("lang") language: String,
+        @Query("id") id: String
+    ): ArtistDetails
+
+    @GET("/{lang}/api/2/PaintingsByArtist")
+    suspend fun paintingsByArtist(
+        @Path("lang") language: String,
+        @Query("artistId") id: String,
+        @Query("json") json: Int = 2
+    ): PaintingList
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistDetails.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistDetails.kt
@@ -1,0 +1,9 @@
+package com.example.wikiart.model
+
+/**
+ * Represents additional details for an artist retrieved from the API.
+ */
+data class ArtistDetails(
+    val id: String?,
+    val biography: String?
+)

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
@@ -1,0 +1,57 @@
+package com.example.wikiart.ui.artists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.wikiart.R
+import com.example.wikiart.databinding.FragmentArtistDetailBinding
+import com.example.wikiart.ui.paintings.PaintingAdapter
+import com.example.wikiart.ui.paintings.PaintingDetailFragment
+
+class ArtistDetailFragment : Fragment() {
+
+    private var _binding: FragmentArtistDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ArtistDetailViewModel by viewModels {
+        ArtistDetailViewModel.Factory(requireArguments().getString(ARG_ARTIST_ID)!!)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentArtistDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val adapter = PaintingAdapter(PaintingAdapter.Layout.GRID) { painting ->
+            val bundle = Bundle().apply { putString(PaintingDetailFragment.ARG_PAINTING_ID, painting.id) }
+            findNavController().navigate(R.id.action_artistDetailFragment_to_paintingDetailFragment, bundle)
+        }
+        binding.paintingsRecyclerView.adapter = adapter
+        binding.paintingsRecyclerView.layoutManager = GridLayoutManager(requireContext(), 2)
+
+        viewModel.biography.observe(viewLifecycleOwner) { binding.biographyText.text = it }
+        viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
+        viewModel.loading.observe(viewLifecycleOwner) { binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_ARTIST_ID = "artist_id"
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailViewModel.kt
@@ -1,0 +1,52 @@
+package com.example.wikiart.ui.artists
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.ArtistDetailsRepository
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.launch
+
+class ArtistDetailViewModel(
+    private val artistId: String,
+    private val repository: ArtistDetailsRepository = ArtistDetailsRepository()
+) : ViewModel() {
+
+    private val _biography = MutableLiveData<String>()
+    val biography: LiveData<String> = _biography
+
+    private val _paintings = MutableLiveData<List<Painting>>(emptyList())
+    val paintings: LiveData<List<Painting>> = _paintings
+
+    private val _loading = MutableLiveData(false)
+    val loading: LiveData<Boolean> = _loading
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _loading.value = true
+            try {
+                val details = repository.getArtistDetails(artistId)
+                _biography.value = details.biography
+                _paintings.value = repository.getArtistPaintings(artistId)
+            } catch (_: Exception) {
+            }
+            _loading.value = false
+        }
+    }
+
+    class Factory(private val artistId: String) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ArtistDetailViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return ArtistDetailViewModel(artistId) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
@@ -12,6 +12,7 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,7 +45,10 @@ class ArtistsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = ArtistAdapter(viewModel.layout)
+        adapter = ArtistAdapter(viewModel.layout) { artist ->
+            val bundle = Bundle().apply { putString(ArtistDetailFragment.ARG_ARTIST_ID, artist.id) }
+            findNavController().navigate(R.id.action_artistsFragment_to_artistDetailFragment, bundle)
+        }
         binding.artistRecyclerView.adapter = adapter
         binding.artistRecyclerView.layoutManager = layoutManagerFor(viewModel.layout)
 

--- a/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/biographyText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:textAppearance="?attr/textAppearanceBody1" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Artworks"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/paintingsRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:layout_margin="8dp" />
+        </LinearLayout>
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -19,7 +19,11 @@
         android:id="@+id/navigation_artists"
         android:name="com.example.wikiart.ui.artists.ArtistsFragment"
         android:label="@string/title_artists"
-        tools:layout="@layout/fragment_artists" />
+        tools:layout="@layout/fragment_artists" >
+        <action
+            android:id="@+id/action_artistsFragment_to_artistDetailFragment"
+            app:destination="@id/artistDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_search"
@@ -40,6 +44,16 @@
         tools:layout="@layout/fragment_painting_detail" >
         <action
             android:id="@+id/action_paintingDetailFragment_self"
+            app:destination="@id/paintingDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/artistDetailFragment"
+        android:name="com.example.wikiart.ui.artists.ArtistDetailFragment"
+        android:label="@string/title_artist_detail"
+        tools:layout="@layout/fragment_artist_detail" >
+        <action
+            android:id="@+id/action_artistDetailFragment_to_paintingDetailFragment"
             app:destination="@id/paintingDetailFragment" />
     </fragment>
 </navigation>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="layout_sheet">Sheet</string>
     <string name="action_options">Options</string>
     <string name="title_painting_detail">Painting</string>
+    <string name="title_artist_detail">Artist</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add ArtistDetailFragment and layout to show artist biography and artworks
- Implement ArtistDetailViewModel and repository to load biography and associated paintings
- Wire navigation from artist list to new detail screen and onward to painting details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6482a4e10832ea4d7549757b3cd97