### PR TITLE
Implement search with grouped results and autocomplete

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
@@ -1,0 +1,21 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.ArtistList
+import com.example.wikiart.model.AutocompleteResult
+import com.example.wikiart.model.PaintingList
+
+class SearchRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun searchPaintings(term: String, page: Int): PaintingList {
+        return service.searchPaintings(language = "en", term = term, page = page)
+    }
+
+    suspend fun searchArtists(term: String, page: Int): ArtistList {
+        return service.searchArtists(language = "en", term = term, page = page)
+    }
+
+    suspend fun autocomplete(term: String): AutocompleteResult {
+        return service.autocomplete(language = "en", term = term)
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -4,6 +4,7 @@ import com.example.wikiart.model.Painting
 import com.example.wikiart.model.PaintingList
 import com.example.wikiart.model.ArtistList
 import com.example.wikiart.model.ArtistDetails
+import com.example.wikiart.model.AutocompleteResult
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -58,4 +59,29 @@ interface WikiArtService {
         @Query("json") json: Int = 3,
         @Query("layout") layout: String = "new"
     ): ArtistList
+
+    @GET("/{lang}/App/Search/Paintings")
+    suspend fun searchPaintings(
+        @Path("lang") language: String,
+        @Query("term") term: String,
+        @Query("page") page: Int,
+        @Query("json") json: Int = 3,
+        @Query("layout") layout: String = "new"
+    ): PaintingList
+
+    @GET("/{lang}/App/Search/Artists")
+    suspend fun searchArtists(
+        @Path("lang") language: String,
+        @Query("term") term: String,
+        @Query("page") page: Int,
+        @Query("json") json: Int = 3,
+        @Query("layout") layout: String = "new"
+    ): ArtistList
+
+    @GET("/{lang}/autocomplete")
+    suspend fun autocomplete(
+        @Path("lang") language: String,
+        @Query("term") term: String,
+        @Query("json") json: Int = 1
+    ): AutocompleteResult
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/AutocompleteResult.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/AutocompleteResult.kt
@@ -1,0 +1,5 @@
+package com.example.wikiart.model
+
+data class AutocompleteResult(
+    val terms: List<String>
+)

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchAdapter.kt
@@ -1,0 +1,93 @@
+package com.example.wikiart.ui.search
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.example.wikiart.R
+import com.example.wikiart.model.Artist
+import com.example.wikiart.model.Painting
+
+sealed class SearchItem {
+    data class Header(val title: String) : SearchItem()
+    data class PaintingItem(val painting: Painting) : SearchItem()
+    data class ArtistItem(val artist: Artist) : SearchItem()
+    data class SuggestionItem(val term: String) : SearchItem()
+}
+
+class SearchAdapter(
+    private val onPainting: (Painting) -> Unit,
+    private val onArtist: (Artist) -> Unit,
+    private val onSuggestion: (String) -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private val items = mutableListOf<SearchItem>()
+
+    fun submitList(data: List<SearchItem>) {
+        items.clear()
+        items.addAll(data)
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int = when(items[position]) {
+        is SearchItem.Header -> 0
+        is SearchItem.PaintingItem -> 1
+        is SearchItem.ArtistItem -> 2
+        is SearchItem.SuggestionItem -> 3
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder = when(viewType) {
+        0 -> HeaderVH(LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false))
+        1 -> PaintingVH(LayoutInflater.from(parent.context).inflate(R.layout.item_painting_list, parent, false))
+        2 -> ArtistVH(LayoutInflater.from(parent.context).inflate(R.layout.item_artist_list, parent, false))
+        else -> SuggestionVH(LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when(val item = items[position]) {
+            is SearchItem.Header -> (holder as HeaderVH).bind(item.title)
+            is SearchItem.PaintingItem -> (holder as PaintingVH).bind(item.painting, onPainting)
+            is SearchItem.ArtistItem -> (holder as ArtistVH).bind(item.artist, onArtist)
+            is SearchItem.SuggestionItem -> (holder as SuggestionVH).bind(item.term, onSuggestion)
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class HeaderVH(view: View) : RecyclerView.ViewHolder(view) {
+        private val text: TextView = view.findViewById(android.R.id.text1)
+        fun bind(title: String) { text.text = title }
+    }
+
+    class SuggestionVH(view: View) : RecyclerView.ViewHolder(view) {
+        private val text: TextView = view.findViewById(android.R.id.text1)
+        fun bind(term: String, listener: (String) -> Unit) {
+            text.text = term
+            itemView.setOnClickListener { listener(term) }
+        }
+    }
+
+    class PaintingVH(view: View) : RecyclerView.ViewHolder(view) {
+        private val image: android.widget.ImageView = view.findViewById(R.id.paintingImage)
+        private val title: TextView? = view.findViewById(R.id.paintingTitle)
+        private val artist: TextView? = view.findViewById(R.id.paintingArtist)
+        fun bind(p: Painting, listener: (Painting) -> Unit) {
+            image.load(p.imageUrl())
+            title?.text = p.title
+            artist?.text = p.artistName
+            itemView.setOnClickListener { listener(p) }
+        }
+    }
+
+    class ArtistVH(view: View) : RecyclerView.ViewHolder(view) {
+        private val image: android.widget.ImageView = view.findViewById(R.id.artistImage)
+        private val name: TextView = view.findViewById(R.id.artistName)
+        fun bind(a: Artist, listener: (Artist) -> Unit) {
+            image.load(a.image)
+            name.text = a.title
+            itemView.setOnClickListener { listener(a) }
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
@@ -4,35 +4,88 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.wikiart.R
 import com.example.wikiart.databinding.FragmentSearchBinding
+import com.example.wikiart.ui.artists.ArtistDetailFragment
+import com.example.wikiart.ui.paintings.PaintingDetailFragment
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class SearchFragment : Fragment() {
 
     private var _binding: FragmentSearchBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
     private val binding get() = _binding!!
+
+    private val viewModel: SearchViewModel by viewModels()
+    private lateinit var adapter: SearchAdapter
+    private var autocompleteJob: Job? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val searchViewModel =
-            ViewModelProvider(this).get(SearchViewModel::class.java)
-
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        return binding.root
+    }
 
-        val textView: TextView = binding.textSearch
-        searchViewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
-        }
-        return root
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        adapter = SearchAdapter(
+            onPainting = { painting ->
+                val bundle = Bundle().apply { putString(PaintingDetailFragment.ARG_PAINTING_ID, painting.id) }
+                findNavController().navigate(R.id.action_search_to_paintingDetailFragment, bundle)
+            },
+            onArtist = { artist ->
+                val bundle = Bundle().apply { putString(ArtistDetailFragment.ARG_ARTIST_PATH, artist.artistUrl ?: "") }
+                findNavController().navigate(R.id.action_search_to_artistDetailFragment, bundle)
+            },
+            onSuggestion = { term ->
+                binding.searchBar.setQuery(term, false)
+                viewModel.search(term)
+            }
+        )
+
+        binding.resultsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.resultsRecyclerView.adapter = adapter
+        binding.resultsRecyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                val lm = recyclerView.layoutManager as LinearLayoutManager
+                val last = lm.findLastVisibleItemPosition()
+                if (last >= adapter.itemCount - 5) {
+                    viewModel.loadMorePaintings()
+                    viewModel.loadMoreArtists()
+                }
+            }
+        })
+
+        binding.searchBar.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String): Boolean {
+                viewModel.search(query)
+                binding.searchBar.clearFocus()
+                return true
+            }
+
+            override fun onQueryTextChange(newText: String): Boolean {
+                autocompleteJob?.cancel()
+                autocompleteJob = viewLifecycleOwner.lifecycleScope.launch {
+                    delay(300)
+                    viewModel.autocomplete(newText)
+                }
+                return true
+            }
+        })
+
+        viewModel.items.observe(viewLifecycleOwner) { adapter.submitList(it) }
     }
 
     override fun onDestroyView() {

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
@@ -3,11 +3,102 @@ package com.example.wikiart.ui.search
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.SearchRepository
+import com.example.wikiart.model.Artist
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.launch
 
 class SearchViewModel : ViewModel() {
+    private val repository = SearchRepository()
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is search Fragment"
+    private val paintings = mutableListOf<Painting>()
+    private val artists = mutableListOf<Artist>()
+    private val suggestions = MutableLiveData<List<String>>(emptyList())
+
+    private val _items = MutableLiveData<List<SearchItem>>(emptyList())
+    val items: LiveData<List<SearchItem>> = _items
+
+    private var paintingsPage = 1
+    private var artistsPage = 1
+    private var query: String = ""
+    private var loadingPaintings = false
+    private var loadingArtists = false
+
+    fun search(term: String) {
+        query = term
+        paintings.clear()
+        artists.clear()
+        paintingsPage = 1
+        artistsPage = 1
+        suggestions.value = emptyList()
+        buildItems()
+        loadMorePaintings()
+        loadMoreArtists()
     }
-    val text: LiveData<String> = _text
+
+    fun loadMorePaintings() {
+        if (loadingPaintings || query.isEmpty()) return
+        loadingPaintings = true
+        viewModelScope.launch {
+            try {
+                val result = repository.searchPaintings(query, paintingsPage)
+                paintings.addAll(result.Paintings)
+                paintingsPage++
+                buildItems()
+            } finally {
+                loadingPaintings = false
+            }
+        }
+    }
+
+    fun loadMoreArtists() {
+        if (loadingArtists || query.isEmpty()) return
+        loadingArtists = true
+        viewModelScope.launch {
+            try {
+                val result = repository.searchArtists(query, artistsPage)
+                artists.addAll(result.Artists)
+                artistsPage++
+                buildItems()
+            } finally {
+                loadingArtists = false
+            }
+        }
+    }
+
+    fun autocomplete(term: String) {
+        viewModelScope.launch {
+            if (term.isEmpty()) {
+                suggestions.value = emptyList()
+                buildItems()
+                return@launch
+            }
+            try {
+                val result = repository.autocomplete(term)
+                suggestions.value = result.terms
+            } catch (_: Exception) {
+                suggestions.value = emptyList()
+            }
+            buildItems()
+        }
+    }
+
+    private fun buildItems() {
+        val data = mutableListOf<SearchItem>()
+        val sugg = suggestions.value ?: emptyList()
+        if (sugg.isNotEmpty()) {
+            data.add(SearchItem.Header("Suggestions"))
+            data.addAll(sugg.map { SearchItem.SuggestionItem(it) })
+        }
+        if (paintings.isNotEmpty()) {
+            data.add(SearchItem.Header("Paintings"))
+            data.addAll(paintings.map { SearchItem.PaintingItem(it) })
+        }
+        if (artists.isNotEmpty()) {
+            data.add(SearchItem.Header("Artists"))
+            data.addAll(artists.map { SearchItem.ArtistItem(it) })
+        }
+        _items.postValue(data)
+    }
 }

--- a/WikiArt/app/src/main/res/layout/fragment_search.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_search.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.search.SearchFragment">
+    android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/text_search"
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/search_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="wrap_content"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/resultsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+</LinearLayout>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -29,7 +29,14 @@
         android:id="@+id/navigation_search"
         android:name="com.example.wikiart.ui.search.SearchFragment"
         android:label="@string/title_search"
-        tools:layout="@layout/fragment_search" />
+        tools:layout="@layout/fragment_search" >
+        <action
+            android:id="@+id/action_search_to_paintingDetailFragment"
+            app:destination="@id/paintingDetailFragment" />
+        <action
+            android:id="@+id/action_search_to_artistDetailFragment"
+            app:destination="@id/artistDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_support"


### PR DESCRIPTION
## Summary
- Replace search screen with search bar and RecyclerView showing results
- Add Retrofit endpoints, models, and repository for paintings, artists, and autocomplete
- Group results into sections and support incremental loading with debounce autocomplete

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ad21c18832e9967423b230d9347