### PR TITLE
Adjust grid item layout to match painting dimensions

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -54,6 +54,12 @@ class PaintingAdapter(layout: Layout, private val listener: ((Painting) -> Unit)
         private val artist: TextView? = view.findViewById(R.id.paintingArtist)
 
         fun bind(p: Painting, listener: ((Painting) -> Unit)?) {
+            if (layout == Layout.GRID) {
+                val params = image.layoutParams
+                params.width = p.width
+                params.height = p.height
+                image.layoutParams = params
+            }
             image.load(p.imageUrl())
             title?.text = p.title
             artist?.text = p.artistName

--- a/WikiArt/app/src/main/res/layout/item_painting_grid.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_grid.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="4dp">
 
     <ImageView
         android:id="@+id/paintingImage"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true" />
 


### PR DESCRIPTION
## Summary
- set grid item layout to wrap content and adjust view bounds for images
- size grid images from Painting model in adapter

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72d77740c832e9893e0c21e0eeddc