### PR TITLE
Adjust grid item dimensions based on painting metadata

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -54,6 +54,12 @@ class PaintingAdapter(layout: Layout, private val listener: ((Painting) -> Unit)
         private val artist: TextView? = view.findViewById(R.id.paintingArtist)
 
         fun bind(p: Painting, listener: ((Painting) -> Unit)?) {
+            if (layout == Layout.GRID) {
+                val lp = image.layoutParams
+                lp.width = p.width
+                lp.height = p.height
+                image.layoutParams = lp
+            }
             image.load(p.imageUrl())
             title?.text = p.title
             artist?.text = p.artistName

--- a/WikiArt/app/src/main/res/layout/item_painting_grid.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_grid.xml
@@ -7,7 +7,7 @@
 
     <ImageView
         android:id="@+id/paintingImage"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true" />
 


### PR DESCRIPTION
## Summary
- Allow grid painting images to size themselves with `wrap_content` and `adjustViewBounds`
- Set image view layout params from Painting width and height when binding

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72f4edbd4832ea586df70e0208800