### PR TITLE
Add artist category sections and search support

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsCategoryRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsCategoryRepository.kt
@@ -1,0 +1,19 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.ArtistCategory
+import com.example.wikiart.model.ArtistSection
+
+/**
+ * Repository providing sections for a given artist category.
+ */
+class ArtistsCategoryRepository(
+    private val service: WikiArtService = ApiClient.service
+) {
+    suspend fun getSections(category: ArtistCategory): List<ArtistSection> {
+        return service.artistSections(
+            language = "en",
+            category = category.path
+        ).items
+    }
+}
+

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
@@ -4,11 +4,16 @@ import com.example.wikiart.model.ArtistCategory
 import com.example.wikiart.model.ArtistList
 
 class ArtistsRepository {
-    suspend fun getArtists(category: ArtistCategory, page: Int): ArtistList {
+    suspend fun getArtists(
+        category: ArtistCategory,
+        page: Int,
+        section: String? = null
+    ): ArtistList {
         return ApiClient.service.artistsByCategory(
             language = "en",
             category = category.path,
-            page = page
+            page = page,
+            searchTerm = section
         )
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -5,6 +5,7 @@ import com.example.wikiart.model.PaintingList
 import com.example.wikiart.model.ArtistList
 import com.example.wikiart.model.ArtistDetails
 import com.example.wikiart.model.AutocompleteResult
+import com.example.wikiart.model.ArtistSections
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -57,8 +58,16 @@ interface WikiArtService {
         @Path("category") category: String,
         @Query("page") page: Int,
         @Query("json") json: Int = 3,
-        @Query("layout") layout: String = "new"
+        @Query("layout") layout: String = "new",
+        @Query("searchterm") searchTerm: String? = null
     ): ArtistList
+
+    @GET("/{lang}/App/Search/{category}")
+    suspend fun artistSections(
+        @Path("lang") language: String,
+        @Path("category") category: String,
+        @Query("json") json: Int = 2
+    ): ArtistSections
 
     @GET("/{lang}/App/Search/Paintings")
     suspend fun searchPaintings(

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistSection.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistSection.kt
@@ -1,0 +1,25 @@
+package com.example.wikiart.model
+
+/**
+ * Represents a section within an artist category returned by the API.
+ */
+data class ArtistSection(
+    val Url: String,
+    val Title: String,
+    val Count: Int
+) {
+    val url: String
+        get() = Url.substringAfterLast('/')
+}
+
+/**
+ * API response wrapper for artist sections. The sections are grouped by a dictionary
+ * but the app only cares about the flattened list.
+ */
+data class ArtistSections(
+    val DictionariesWithCategories: Map<String, List<ArtistSection>>
+) {
+    val items: List<ArtistSection>
+        get() = DictionariesWithCategories.values.flatten()
+}
+

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
@@ -5,15 +5,21 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.wikiart.api.ArtistsRepository
+import com.example.wikiart.api.ArtistsCategoryRepository
 import com.example.wikiart.model.Artist
 import com.example.wikiart.model.ArtistCategory
+import com.example.wikiart.model.ArtistSection
 import kotlinx.coroutines.launch
 
 class ArtistListViewModel : ViewModel() {
     private val repository = ArtistsRepository()
+    private val categoryRepository = ArtistsCategoryRepository()
 
     private val _artists = MutableLiveData<List<Artist>>(emptyList())
     val artists: LiveData<List<Artist>> = _artists
+
+    private val _sections = MutableLiveData<List<ArtistSection>>(emptyList())
+    val sections: LiveData<List<ArtistSection>> = _sections
 
     private val _loading = MutableLiveData(false)
     val loading: LiveData<Boolean> = _loading
@@ -24,8 +30,14 @@ class ArtistListViewModel : ViewModel() {
     private var page = 1
     var category: ArtistCategory = ArtistCategory.POPULAR
         private set
+    var section: ArtistSection? = null
+        private set
     var layout: ArtistAdapter.Layout = ArtistAdapter.Layout.LIST
         private set
+
+    init {
+        loadSections()
+    }
 
     fun loadNext() {
         if (_loading.value == true) return
@@ -33,7 +45,7 @@ class ArtistListViewModel : ViewModel() {
         _error.value = null
         viewModelScope.launch {
             try {
-                val result = repository.getArtists(category, page)
+                val result = repository.getArtists(category, page, section?.url)
                 _artists.value = _artists.value!! + result.Artists
                 page++
             } catch (e: Exception) {
@@ -47,11 +59,31 @@ class ArtistListViewModel : ViewModel() {
         if (category == cat) return
         category = cat
         page = 1
+        section = null
+        _artists.value = emptyList()
+        loadSections()
+        loadNext()
+    }
+
+    fun setSection(sec: ArtistSection?) {
+        if (section == sec) return
+        section = sec
+        page = 1
         _artists.value = emptyList()
         loadNext()
     }
 
     fun setLayout(l: ArtistAdapter.Layout) {
         layout = l
+    }
+
+    private fun loadSections() {
+        viewModelScope.launch {
+            try {
+                _sections.value = categoryRepository.getSections(category)
+            } catch (_: Exception) {
+                _sections.value = emptyList()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand WikiArtService with artist section endpoint and search term support
- introduce ArtistSection models and repository to load category sections
- expose category sections and filtering in ArtistListViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a734e94fb8832e8d70e6a6f1df6bed