### PR TITLE
Implement painting detail actions

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/data/FavoritesRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/data/FavoritesRepository.kt
@@ -1,0 +1,37 @@
+package com.example.wikiart.data
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class FavoritesRepository(context: Context) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun isFavorite(id: String): Boolean {
+        val set = prefs.getStringSet(KEY_FAVORITES, emptySet()) ?: emptySet()
+        return set.contains(id)
+    }
+
+    /**
+     * Toggle favorite state for the given painting id.
+     * @return true if the painting is now a favorite, false otherwise.
+     */
+    fun toggleFavorite(id: String): Boolean {
+        val set = prefs.getStringSet(KEY_FAVORITES, emptySet())?.toMutableSet() ?: mutableSetOf()
+        val added: Boolean = if (set.contains(id)) {
+            set.remove(id)
+            false
+        } else {
+            set.add(id)
+            true
+        }
+        prefs.edit().putStringSet(KEY_FAVORITES, set).apply()
+        return added
+    }
+
+    companion object {
+        private const val PREFS_NAME = "favorites"
+        private const val KEY_FAVORITES = "painting_ids"
+    }
+}
+

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -24,4 +24,7 @@
     <string name="support_message_hint">Message</string>
     <string name="support_send_feedback">Send Feedback</string>
     <string name="support_donate">Donate</string>
+    <string name="favorite">Favorite</string>
+    <string name="unfavorite">Unfavorite</string>
+    <string name="share_painting">Share painting</string>
 </resources>


### PR DESCRIPTION
## Summary
- add FavoritesRepository to manage favorite paintings
- enable favorite toggle, sharing, and buy intents in PaintingDetailFragment
- add strings for favorite state and sharing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74103177c832ebb69c30f21f4234f