### PR TITLE
Add artist paintings fragment with paging

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistPaintingsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistPaintingsRepository.kt
@@ -1,0 +1,11 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.Painting
+
+class ArtistPaintingsRepository(
+    private val service: WikiArtService = ApiClient.service,
+) {
+    suspend fun getPaintings(path: String, page: Int): List<Painting> {
+        return service.artistPaintings("$path/all-works", page = page).Paintings
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistDetailFragment.kt
@@ -48,6 +48,11 @@ class ArtistDetailFragment : Fragment() {
         viewModel.loading.observe(viewLifecycleOwner) {
             binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
         }
+
+        binding.seeAllButton.setOnClickListener {
+            val bundle = Bundle().apply { putString(ArtistPaintingsFragment.ARG_ARTIST_PATH, requireArguments().getString(ARG_ARTIST_PATH)) }
+            findNavController().navigate(R.id.action_artistDetailFragment_to_artistPaintingsFragment, bundle)
+        }
     }
 
     override fun onDestroyView() {

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistPaintingsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistPaintingsFragment.kt
@@ -1,0 +1,75 @@
+package com.example.wikiart.ui.artists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.wikiart.R
+import com.example.wikiart.databinding.FragmentArtistPaintingsBinding
+import com.example.wikiart.ui.paintings.PaintingAdapter
+import com.example.wikiart.ui.paintings.PaintingDetailFragment
+
+class ArtistPaintingsFragment : Fragment() {
+
+    private var _binding: FragmentArtistPaintingsBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ArtistPaintingsViewModel by viewModels {
+        ArtistPaintingsViewModel.Factory(requireArguments().getString(ARG_ARTIST_PATH)!!)
+    }
+
+    private lateinit var adapter: PaintingAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentArtistPaintingsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        adapter = PaintingAdapter(PaintingAdapter.Layout.GRID) { painting ->
+            val bundle = Bundle().apply { putString(PaintingDetailFragment.ARG_PAINTING_ID, painting.id) }
+            findNavController().navigate(R.id.action_artistPaintingsFragment_to_paintingDetailFragment, bundle)
+        }
+        binding.paintingsRecyclerView.adapter = adapter
+        binding.paintingsRecyclerView.layoutManager = GridLayoutManager(requireContext(), 2)
+
+        viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
+        viewModel.loading.observe(viewLifecycleOwner) { binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE }
+        viewModel.error.observe(viewLifecycleOwner) { err ->
+            err?.let { Toast.makeText(requireContext(), it.localizedMessage ?: "Load failed", Toast.LENGTH_SHORT).show() }
+        }
+
+        viewModel.loadNext()
+
+        binding.paintingsRecyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                val manager = recyclerView.layoutManager as GridLayoutManager
+                val lastVisible = manager.findLastVisibleItemPosition()
+                if (lastVisible >= adapter.itemCount - 5) {
+                    viewModel.loadNext()
+                }
+            }
+        })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_ARTIST_PATH = "artist_path"
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistPaintingsViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistPaintingsViewModel.kt
@@ -1,0 +1,53 @@
+package com.example.wikiart.ui.artists
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.wikiart.api.ArtistPaintingsRepository
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.launch
+
+class ArtistPaintingsViewModel(
+    private val artistPath: String,
+    private val repository: ArtistPaintingsRepository = ArtistPaintingsRepository(),
+) : ViewModel() {
+
+    private val _paintings = MutableLiveData<List<Painting>>(emptyList())
+    val paintings: LiveData<List<Painting>> = _paintings
+
+    private val _loading = MutableLiveData(false)
+    val loading: LiveData<Boolean> = _loading
+
+    private val _error = MutableLiveData<Throwable?>(null)
+    val error: LiveData<Throwable?> = _error
+
+    private var page = 1
+
+    fun loadNext() {
+        if (_loading.value == true) return
+        _loading.value = true
+        _error.value = null
+        viewModelScope.launch {
+            try {
+                val result = repository.getPaintings(artistPath, page)
+                _paintings.value = _paintings.value!! + result
+                page++
+            } catch (e: Exception) {
+                _error.value = e
+            }
+            _loading.value = false
+        }
+    }
+
+    class Factory(private val artistPath: String) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ArtistPaintingsViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return ArtistPaintingsViewModel(artistPath) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artist_detail.xml
@@ -32,6 +32,14 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="8dp"
                 android:nestedScrollingEnabled="false" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/seeAllButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="16dp"
+                android:text="@string/see_all" />
         </LinearLayout>
     </ScrollView>
 

--- a/WikiArt/app/src/main/res/layout/fragment_artist_paintings.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artist_paintings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/paintingsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -62,5 +62,18 @@
         <action
             android:id="@+id/action_artistDetailFragment_to_paintingDetailFragment"
             app:destination="@id/paintingDetailFragment" />
+        <action
+            android:id="@+id/action_artistDetailFragment_to_artistPaintingsFragment"
+            app:destination="@id/artistPaintingsFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/artistPaintingsFragment"
+        android:name="com.example.wikiart.ui.artists.ArtistPaintingsFragment"
+        android:label="@string/title_artist_paintings"
+        tools:layout="@layout/fragment_artist_paintings" >
+        <action
+            android:id="@+id/action_artistPaintingsFragment_to_paintingDetailFragment"
+            app:destination="@id/paintingDetailFragment" />
     </fragment>
 </navigation>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="favorite">Favorite</string>
     <string name="unfavorite">Unfavorite</string>
     <string name="share_painting">Share painting</string>
+    <string name="see_all">See All</string>
+    <string name="title_artist_paintings">Paintings</string>
 </resources>


### PR DESCRIPTION
## Summary
- add ArtistPaintingsFragment with grid RecyclerView and infinite scroll
- implement ArtistPaintingsViewModel and repository to page through artist paintings
- add See All button on artist detail and wire navigation to new fragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74fb06220832eae9966d138595269