### PR TITLE
Add painting section filtering

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingSectionsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingSectionsRepository.kt
@@ -1,0 +1,25 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.PaintingCategory
+import com.example.wikiart.model.PaintingSection
+
+/**
+ * Repository providing painting sections for a given category.
+ */
+class PaintingSectionsRepository(
+    private val service: WikiArtService = ApiClient.service,
+) {
+    suspend fun getSections(category: PaintingCategory): List<PaintingSection> {
+        val group = when (category) {
+            PaintingCategory.STYLE -> 2
+            PaintingCategory.GENRE -> 3
+            PaintingCategory.MEDIA -> 12
+            else -> return emptyList()
+        }
+        return service.paintingSections(
+            language = "en",
+            group = group
+        )
+    }
+}
+

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/WikiArtService.kt
@@ -6,6 +6,7 @@ import com.example.wikiart.model.ArtistList
 import com.example.wikiart.model.ArtistDetails
 import com.example.wikiart.model.AutocompleteResult
 import com.example.wikiart.model.ArtistSections
+import com.example.wikiart.model.PaintingSection
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -68,6 +69,20 @@ interface WikiArtService {
         @Path("category") category: String,
         @Query("json") json: Int = 2
     ): ArtistSections
+
+    @GET("/{lang}/app/dictionary/GetAllGroup")
+    suspend fun paintingSections(
+        @Path("lang") language: String,
+        @Query("group") group: Int
+    ): List<PaintingSection>
+
+    @GET("/{lang}/App/Search/PaintingAdvancedSearch")
+    suspend fun paintingsBySection(
+        @Path("lang") language: String,
+        @Query("dictIdsJson") dictIdsJson: String,
+        @Query("page") page: Int,
+        @Query("json") json: Int = 2
+    ): PaintingList
 
     @GET("/{lang}/App/Search/Paintings")
     suspend fun searchPaintings(

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
@@ -1,0 +1,27 @@
+package com.example.wikiart.model
+
+/**
+ * Represents a section within a painting category returned by the API.
+ */
+data class PaintingSection(
+    val _id: Id,
+    val Content: Content
+) {
+    data class Id(val _oid: String)
+    data class Content(val Title: TitleContent) {
+        data class TitleContent(val Title: Map<String, String>)
+    }
+
+    /**
+     * Section identifier used in API calls.
+     */
+    val url: String
+        get() = _id._oid
+
+    /**
+     * Localized title resolved from the map of translations.
+     */
+    val title: String
+        get() = Content.Title.Title["en"] ?: Content.Title.Title.values.firstOrNull().orEmpty()
+}
+

--- a/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
@@ -22,6 +22,14 @@
         android:layout_gravity="top|end"
         android:layout_margin="16dp" />
 
+    <Spinner
+        android:id="@+id/sectionSelector"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|start"
+        android:layout_margin="16dp"
+        android:visibility="gone" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/categoryButton"
         android:layout_width="wrap_content"

--- a/WikiArt/app/src/test/java/com/example/wikiart/ui/paintings/PaintingListViewModelTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/ui/paintings/PaintingListViewModelTest.kt
@@ -2,9 +2,7 @@ package com.example.wikiart.ui.paintings
 
 import com.example.wikiart.api.ApiClient
 import com.example.wikiart.api.WikiArtService
-import com.example.wikiart.model.Painting
-import com.example.wikiart.model.PaintingCategory
-import com.example.wikiart.model.PaintingList
+import com.example.wikiart.model.*
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -48,6 +46,59 @@ class PaintingListViewModelTest {
             return PaintingList(listOf(p), 1, 1)
         }
         override suspend fun paintingDetails(language: String, id: String): Painting {
+            throw NotImplementedError()
+        }
+
+        override suspend fun relatedPaintings(path: String, json: Int): PaintingList {
+            throw NotImplementedError()
+        }
+
+        override suspend fun artistDetails(path: String, json: Int): ArtistDetails {
+            throw NotImplementedError()
+        }
+
+        override suspend fun artistPaintings(path: String, json: Int, page: Int): PaintingList {
+            throw NotImplementedError()
+        }
+
+        override suspend fun artistsByCategory(language: String, category: String, page: Int, json: Int, layout: String, searchTerm: String?): ArtistList {
+            throw NotImplementedError()
+        }
+
+        override suspend fun artistSections(language: String, category: String, json: Int): ArtistSections {
+            throw NotImplementedError()
+        }
+
+        override suspend fun paintingSections(language: String, group: Int): List<PaintingSection> {
+            return emptyList()
+        }
+
+        override suspend fun paintingsBySection(language: String, dictIdsJson: String, page: Int, json: Int): PaintingList {
+            lastPageRequested = page
+            val p = Painting(
+                id = dictIdsJson + page,
+                title = "Title$page",
+                year = "",
+                width = 0,
+                height = 0,
+                artistName = "Artist",
+                image = "url",
+                paintingUrl = "",
+                artistUrl = null,
+                flags = 0
+            )
+            return PaintingList(listOf(p), 1, 1)
+        }
+
+        override suspend fun searchPaintings(language: String, term: String, page: Int, json: Int, layout: String): PaintingList {
+            throw NotImplementedError()
+        }
+
+        override suspend fun searchArtists(language: String, term: String, page: Int, json: Int, layout: String): ArtistList {
+            throw NotImplementedError()
+        }
+
+        override suspend fun autocomplete(language: String, term: String, json: Int): AutocompleteResult {
             throw NotImplementedError()
         }
     }


### PR DESCRIPTION
## Summary
- add repository and model for painting category sections
- include section selection in painting list view model and fragment
- expose new API calls for section lists and section-based painting queries

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a759727f40832e8acd85bc90c5cd37