### PR TITLE
Display painting year and dimensions on detail screen

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
@@ -53,6 +53,8 @@ class PaintingDetailFragment : Fragment() {
                 binding.paintingImage.load(it.imageUrl())
                 binding.paintingTitle.text = it.title
                 binding.paintingArtist.text = it.artistName
+                binding.paintingYear.text = it.year
+                binding.paintingSize.text = formatDimensions(it.width, it.height)
                 viewLifecycleOwner.lifecycleScope.launch {
                     updateFavoriteButton(favoritesRepository.isFavorite(it.id))
                 }
@@ -109,5 +111,9 @@ class PaintingDetailFragment : Fragment() {
                 if (isFavorite) R.drawable.baseline_favorite_24 else R.drawable.baseline_favorite_border_24
             )
         }
+    }
+
+    private fun formatDimensions(width: Int, height: Int): String {
+        return if (width > 0 && height > 0) "${width}×${height} cm" else ""
     }
 }

--- a/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
@@ -32,6 +32,22 @@
                 android:paddingEnd="16dp"
                 android:textAppearance="?attr/textAppearanceBodyMedium" />
 
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/paintingYear"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/paintingSize"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:textAppearance="?attr/textAppearanceBodyMedium" />
+
             <LinearLayout
                 android:orientation="horizontal"
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- show painting year and dimensions on detail screen
- format dimensions as "width×height cm"

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75d076510832e8093e398cca89e36