### PR TITLE
Use device locale for WikiArt API

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsCategoryRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsCategoryRepository.kt
@@ -7,12 +7,13 @@ import com.example.wikiart.model.ArtistSection
  * Repository providing sections for a given artist category.
  */
 class ArtistsCategoryRepository(
-    private val service: WikiArtService = ApiClient.service
+    private val service: WikiArtService = ApiClient.service,
+    private val language: String = getLanguage(),
 ) {
     suspend fun getSections(category: ArtistCategory): List<ArtistSection> {
         return service.artistSections(
-            language = "en",
-            category = category.path
+            language = language,
+            category = category.path,
         ).items
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
@@ -3,17 +3,19 @@ package com.example.wikiart.api
 import com.example.wikiart.model.ArtistCategory
 import com.example.wikiart.model.ArtistList
 
-class ArtistsRepository {
+class ArtistsRepository(
+    private val language: String = getLanguage(),
+) {
     suspend fun getArtists(
         category: ArtistCategory,
         page: Int,
-        section: String? = null
+        section: String? = null,
     ): ArtistList {
         return ApiClient.service.artistsByCategory(
-            language = "en",
+            language = language,
             category = category.path,
             page = page,
-            searchTerm = section
+            searchTerm = section,
         )
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/LanguageProvider.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/LanguageProvider.kt
@@ -1,0 +1,11 @@
+package com.example.wikiart.api
+
+import java.util.Locale
+
+private val supportedLanguages = setOf("en", "de", "es", "fr", "it", "pt", "ru", "zh", "ja")
+
+fun getLanguage(): String {
+    val localeLang = Locale.getDefault().language
+    return if (supportedLanguages.contains(localeLang)) localeLang else "en"
+}
+

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
@@ -3,9 +3,10 @@ package com.example.wikiart.api
 import com.example.wikiart.model.Painting
 
 class PaintingDetailsRepository(
-    private val service: WikiArtService = ApiClient.service
+    private val service: WikiArtService = ApiClient.service,
+    private val language: String = getLanguage(),
 ) {
-    suspend fun getPainting(id: String, language: String = "en"): Painting {
+    suspend fun getPainting(id: String): Painting {
         return service.paintingDetails(language, id)
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingSectionsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingSectionsRepository.kt
@@ -8,6 +8,7 @@ import com.example.wikiart.model.PaintingSection
  */
 class PaintingSectionsRepository(
     private val service: WikiArtService = ApiClient.service,
+    private val language: String = getLanguage(),
 ) {
     suspend fun getSections(category: PaintingCategory): List<PaintingSection> {
         val group = when (category) {
@@ -17,8 +18,8 @@ class PaintingSectionsRepository(
             else -> return emptyList()
         }
         return service.paintingSections(
-            language = "en",
-            group = group
+            language = language,
+            group = group,
         )
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
@@ -5,17 +5,18 @@ import com.example.wikiart.model.AutocompleteResult
 import com.example.wikiart.model.PaintingList
 
 class SearchRepository(
-    private val service: WikiArtService = ApiClient.service
+    private val service: WikiArtService = ApiClient.service,
+    private val language: String = getLanguage(),
 ) {
     suspend fun searchPaintings(term: String, page: Int): PaintingList {
-        return service.searchPaintings(language = "en", term = term, page = page)
+        return service.searchPaintings(language = language, term = term, page = page)
     }
 
     suspend fun searchArtists(term: String, page: Int): ArtistList {
-        return service.searchArtists(language = "en", term = term, page = page)
+        return service.searchArtists(language = language, term = term, page = page)
     }
 
     suspend fun autocomplete(term: String): AutocompleteResult {
-        return service.autocomplete(language = "en", term = term)
+        return service.autocomplete(language = language, term = term)
     }
 }

--- a/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
@@ -5,7 +5,7 @@ package com.example.wikiart.model
  */
 data class PaintingSection(
     val _id: Id,
-    val Content: Content
+    val Content: Content,
 ) {
     data class Id(val _oid: String)
     data class Content(val Title: TitleContent) {
@@ -22,6 +22,11 @@ data class PaintingSection(
      * Localized title resolved from the map of translations.
      */
     val title: String
-        get() = Content.Title.Title["en"] ?: Content.Title.Title.values.firstOrNull().orEmpty()
+        get() {
+            val lang = com.example.wikiart.api.getLanguage()
+            return Content.Title.Title[lang]
+                ?: Content.Title.Title["en"]
+                ?: Content.Title.Title.values.firstOrNull().orEmpty()
+        }
 }
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
@@ -6,14 +6,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.wikiart.api.ArtistsRepository
 import com.example.wikiart.api.ArtistsCategoryRepository
+import com.example.wikiart.api.getLanguage
 import com.example.wikiart.model.Artist
 import com.example.wikiart.model.ArtistCategory
 import com.example.wikiart.model.ArtistSection
 import kotlinx.coroutines.launch
 
-class ArtistListViewModel : ViewModel() {
-    private val repository = ArtistsRepository()
-    private val categoryRepository = ArtistsCategoryRepository()
+class ArtistListViewModel(
+    private val language: String = getLanguage(),
+) : ViewModel() {
+    private val repository = ArtistsRepository(language)
+    private val categoryRepository = ArtistsCategoryRepository(language)
 
     private val _artists = MutableLiveData<List<Artist>>(emptyList())
     val artists: LiveData<List<Artist>> = _artists

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import coil.load
 import com.example.wikiart.R
 import com.example.wikiart.api.FavoritesRepository
+import com.example.wikiart.api.getLanguage
 import com.example.wikiart.databinding.FragmentPaintingDetailBinding
 import androidx.lifecycle.lifecycleScope
 import androidx.core.content.ContextCompat
@@ -24,7 +25,10 @@ class PaintingDetailFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: PaintingDetailViewModel by viewModels {
-        PaintingDetailViewModel.Factory(requireArguments().getString(ARG_PAINTING_ID)!!)
+        PaintingDetailViewModel.Factory(
+            requireArguments().getString(ARG_PAINTING_ID)!!,
+            getLanguage(),
+        )
     }
 
     private val favoritesRepository by lazy { FavoritesRepository(requireContext()) }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
@@ -7,13 +7,15 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.wikiart.api.PaintingDetailsRepository
 import com.example.wikiart.api.RelatedPaintingsRepository
+import com.example.wikiart.api.getLanguage
 import com.example.wikiart.model.Painting
 import kotlinx.coroutines.launch
 
 class PaintingDetailViewModel(
     private val paintingId: String,
-    private val detailsRepository: PaintingDetailsRepository = PaintingDetailsRepository(),
-    private val relatedRepository: RelatedPaintingsRepository = RelatedPaintingsRepository()
+    private val language: String = getLanguage(),
+    private val detailsRepository: PaintingDetailsRepository = PaintingDetailsRepository(language),
+    private val relatedRepository: RelatedPaintingsRepository = RelatedPaintingsRepository(),
 ) : ViewModel() {
 
     private val _painting = MutableLiveData<Painting?>()
@@ -43,11 +45,14 @@ class PaintingDetailViewModel(
         }
     }
 
-    class Factory(private val paintingId: String) : ViewModelProvider.Factory {
+    class Factory(
+        private val paintingId: String,
+        private val language: String = getLanguage(),
+    ) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(PaintingDetailViewModel::class.java)) {
                 @Suppress("UNCHECKED_CAST")
-                return PaintingDetailViewModel(paintingId) as T
+                return PaintingDetailViewModel(paintingId, language) as T
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.wikiart.api.FavoritesRepository
+import com.example.wikiart.api.getLanguage
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -27,7 +28,10 @@ class PaintingListFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: PaintingListViewModel by viewModels {
-        PaintingListViewModel.Factory(FavoritesRepository(requireContext()))
+        PaintingListViewModel.Factory(
+            FavoritesRepository(requireContext()),
+            getLanguage(),
+        )
     }
     private lateinit var adapter: PaintingAdapter
     private lateinit var sectionAdapter: ArrayAdapter<String>

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
@@ -5,12 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.wikiart.api.SearchRepository
+import com.example.wikiart.api.getLanguage
 import com.example.wikiart.model.Artist
 import com.example.wikiart.model.Painting
 import kotlinx.coroutines.launch
 
-class SearchViewModel : ViewModel() {
-    private val repository = SearchRepository()
+class SearchViewModel(
+    private val language: String = getLanguage(),
+) : ViewModel() {
+    private val repository = SearchRepository(language)
 
     private val paintings = mutableListOf<Painting>()
     private val artists = mutableListOf<Artist>()


### PR DESCRIPTION
## Summary
- add `getLanguage` utility with supported language fallback
- thread locale language through repositories and view models instead of hard-coded "en"
- pass language to fragments and adapt `PaintingSection` titles

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75feeebbc832e982c8f668605c09b