### PR TITLE
Use staggered sheet layout

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -14,6 +14,7 @@ import com.example.wikiart.api.getLanguage
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import android.widget.ArrayAdapter
 import android.widget.AdapterView
 import android.widget.Toast
@@ -116,8 +117,15 @@ class PaintingListFragment : Fragment() {
 
         binding.paintingRecyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                val manager = recyclerView.layoutManager as LinearLayoutManager
-                val lastVisible = manager.findLastVisibleItemPosition()
+                val lastVisible = when (val manager = recyclerView.layoutManager) {
+                    is LinearLayoutManager -> manager.findLastVisibleItemPosition()
+                    is StaggeredGridLayoutManager -> {
+                        val positions = IntArray(manager.spanCount)
+                        manager.findLastVisibleItemPositions(positions)
+                        positions.maxOrNull() ?: 0
+                    }
+                    else -> return
+                }
                 if (lastVisible >= adapter.itemCount - 5) {
                     viewModel.loadNext()
                 }
@@ -159,7 +167,9 @@ class PaintingListFragment : Fragment() {
     private fun layoutManagerFor(layout: PaintingAdapter.Layout): RecyclerView.LayoutManager = when(layout) {
         PaintingAdapter.Layout.LIST -> LinearLayoutManager(requireContext())
         PaintingAdapter.Layout.GRID -> GridLayoutManager(requireContext(), 2)
-        PaintingAdapter.Layout.SHEET -> GridLayoutManager(requireContext(), 2)
+        PaintingAdapter.Layout.SHEET -> StaggeredGridLayoutManager(1, StaggeredGridLayoutManager.VERTICAL).apply {
+            gapStrategy = StaggeredGridLayoutManager.GAP_HANDLING_NONE
+        }
     }
 
 

--- a/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
@@ -1,6 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/paintingImage"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:adjustViewBounds="true" />
+    android:layout_marginBottom="8dp">
+
+    <ImageView
+        android:id="@+id/paintingImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:orientation="vertical"
+        android:background="#80000000"
+        android:padding="8dp">
+
+        <TextView
+            android:id="@+id/paintingTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="@android:color/white" />
+
+        <TextView
+            android:id="@+id/paintingArtist"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/white" />
+    </LinearLayout>
+
+</FrameLayout>


### PR DESCRIPTION
## Summary
- Use a StaggeredGridLayoutManager for sheet view to show items in a single vertical column
- Style sheet items with full-width images and text overlay for title and artist
- Handle scrolling with either Linear or Staggered grid managers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a73fd4c832e81a19b828a326d4b