### PR TITLE
Add custom sheet layout manager and iOS-style sheet item

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -167,9 +167,7 @@ class PaintingListFragment : Fragment() {
     private fun layoutManagerFor(layout: PaintingAdapter.Layout): RecyclerView.LayoutManager = when(layout) {
         PaintingAdapter.Layout.LIST -> LinearLayoutManager(requireContext())
         PaintingAdapter.Layout.GRID -> GridLayoutManager(requireContext(), 2)
-        PaintingAdapter.Layout.SHEET -> StaggeredGridLayoutManager(1, StaggeredGridLayoutManager.VERTICAL).apply {
-            gapStrategy = StaggeredGridLayoutManager.GAP_HANDLING_NONE
-        }
+        PaintingAdapter.Layout.SHEET -> SheetLayoutManager()
     }
 
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/SheetLayoutManager.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/SheetLayoutManager.kt
@@ -1,0 +1,16 @@
+package com.example.wikiart.ui.paintings
+
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+
+/**
+ * Layout manager used for [PaintingAdapter.Layout.SHEET].
+ *
+ * It is essentially a single column vertical [StaggeredGridLayoutManager]
+ * with gap handling disabled to mimic a full width list layout while still
+ * letting each item measure its own height.
+ */
+class SheetLayoutManager : StaggeredGridLayoutManager(1, VERTICAL) {
+    init {
+        gapStrategy = GAP_HANDLING_NONE
+    }
+}

--- a/WikiArt/app/src/main/res/drawable/painting_sheet_overlay.xml
+++ b/WikiArt/app/src/main/res/drawable/painting_sheet_overlay.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <gradient
+        android:angle="270"
+        android:startColor="#00000000"
+        android:endColor="#80000000"/>
+</shape>

--- a/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
@@ -8,14 +8,15 @@
         android:id="@+id/paintingImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:orientation="vertical"
-        android:background="#80000000"
+        android:background="@drawable/painting_sheet_overlay"
         android:padding="8dp">
 
         <TextView


### PR DESCRIPTION
## Summary
- add `SheetLayoutManager` to provide single-column staggered grid with no gaps for sheet layout
- style sheet item to use center-cropped images and gradient overlay text
- use the new layout manager when the sheet layout is selected

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b40f658832eb92d51f7b32b0e5c