### PR TITLE
Add loading and error handling to search screen

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchFragment.kt
@@ -85,7 +85,38 @@ class SearchFragment : Fragment() {
             }
         })
 
-        viewModel.items.observe(viewLifecycleOwner) { adapter.submitList(it) }
+        viewModel.items.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+            if (it.isEmpty() && viewModel.error.value == null && viewModel.loading.value == false) {
+                binding.emptyMessage.visibility = View.VISIBLE
+                binding.emptyMessage.text = getString(R.string.no_results)
+            } else if (viewModel.error.value == null) {
+                binding.emptyMessage.visibility = View.GONE
+            }
+        }
+
+        viewModel.loading.observe(viewLifecycleOwner) { loading ->
+            binding.loadingProgressBar.visibility = if (loading) View.VISIBLE else View.GONE
+            if (loading) {
+                binding.emptyMessage.visibility = View.GONE
+            } else if (viewModel.items.value.isNullOrEmpty() && viewModel.error.value == null) {
+                binding.emptyMessage.visibility = View.VISIBLE
+                binding.emptyMessage.text = getString(R.string.no_results)
+            }
+        }
+
+        viewModel.error.observe(viewLifecycleOwner) { throwable ->
+            if (throwable != null) {
+                binding.emptyMessage.visibility = View.VISIBLE
+                binding.emptyMessage.text = throwable.localizedMessage
+                    ?: getString(R.string.error_generic)
+            } else if (viewModel.items.value.isNullOrEmpty() && viewModel.loading.value == false) {
+                binding.emptyMessage.visibility = View.VISIBLE
+                binding.emptyMessage.text = getString(R.string.no_results)
+            } else {
+                binding.emptyMessage.visibility = View.GONE
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/WikiArt/app/src/main/res/layout/fragment_search.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_search.xml
@@ -14,4 +14,19 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"/>
+
+    <ProgressBar
+        android:id="@+id/loadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/emptyMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:visibility="gone" />
 </LinearLayout>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
     <string name="share_painting">Share painting</string>
     <string name="see_all">See All</string>
     <string name="title_artist_paintings">Paintings</string>
+    <string name="no_results">No results</string>
+    <string name="error_generic">An error occurred</string>
 </resources>


### PR DESCRIPTION
## Summary
- show progress bar and empty message in search UI
- expose loading and error LiveData in SearchViewModel
- display errors or no-results message in SearchFragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ee91c98832eb545cd4792829127