### PR TITLE
Add pull-to-refresh support for artists and paintings lists

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
@@ -81,6 +81,12 @@ class ArtistListViewModel(
         layout = l
     }
 
+    fun refresh() {
+        page = 1
+        _artists.value = emptyList()
+        loadNext()
+    }
+
     private fun loadSections() {
         viewModelScope.launch {
             try {

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistsFragment.kt
@@ -91,8 +91,17 @@ class ArtistsFragment : Fragment() {
 
         binding.categoryButton.setOnClickListener { openOptions() }
 
+        binding.swipeRefresh.setOnRefreshListener {
+            viewModel.refresh()
+        }
+
         viewModel.artists.observe(viewLifecycleOwner) { adapter.submitList(it) }
-        viewModel.loading.observe(viewLifecycleOwner) { binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE }
+        viewModel.loading.observe(viewLifecycleOwner) {
+            binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
+            if (!it) {
+                binding.swipeRefresh.isRefreshing = false
+            }
+        }
         viewModel.error.observe(viewLifecycleOwner) { err ->
             err?.let { Toast.makeText(requireContext(), it.localizedMessage ?: "Load failed", Toast.LENGTH_SHORT).show() }
         }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListFragment.kt
@@ -93,8 +93,17 @@ class PaintingListFragment : Fragment() {
 
         binding.categoryButton.setOnClickListener { openOptions() }
 
+        binding.swipeRefresh.setOnRefreshListener {
+            viewModel.refresh()
+        }
+
         viewModel.paintings.observe(viewLifecycleOwner) { adapter.submitList(it) }
-        viewModel.loading.observe(viewLifecycleOwner) { binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE }
+        viewModel.loading.observe(viewLifecycleOwner) {
+            binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
+            if (!it) {
+                binding.swipeRefresh.isRefreshing = false
+            }
+        }
         viewModel.error.observe(viewLifecycleOwner) { err ->
             err?.let { Toast.makeText(requireContext(), it.localizedMessage ?: "Load failed", Toast.LENGTH_SHORT).show() }
         }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
@@ -115,6 +115,12 @@ class PaintingListViewModel(
         layout = l
     }
 
+    fun refresh() {
+        page = 1
+        _paintings.value = emptyList()
+        loadNext()
+    }
+
     class Factory(
         private val repo: FavoritesRepository,
         private val language: String = getLanguage(),

--- a/WikiArt/app/src/main/res/layout/fragment_artists.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_artists.xml
@@ -3,10 +3,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/artistRecyclerView"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/artistRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progressBar"

--- a/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_list.xml
@@ -3,10 +3,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/paintingRecyclerView"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/paintingRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progressBar"


### PR DESCRIPTION
## Summary
- wrap artist and painting lists in `SwipeRefreshLayout`
- refresh lists from start when user pulls to refresh
- stop refreshing indicator when data load completes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77039d03c832e839705c9124ca153