### PR TITLE
Add notifications screen backed by Firebase and Room

### DIFF
--- a/WikiArt/app/build.gradle.kts
+++ b/WikiArt/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -54,6 +55,11 @@ dependencies {
     implementation(libs.photoview)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging.ktx)
+    implementation(libs.androidx.room.runtime)
+    kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/WikiArt/app/src/main/AndroidManifest.xml
+++ b/WikiArt/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".WikiArtApplication"
         android:allowBackup="true"
@@ -23,6 +25,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".notifications.WikiArtFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.navigation_paintings,
                 R.id.navigation_artists,
                 R.id.navigation_search,
+                R.id.navigation_notifications,
                 R.id.navigation_support
             )
         )

--- a/WikiArt/app/src/main/java/com/example/wikiart/notifications/Notification.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/notifications/Notification.kt
@@ -1,0 +1,12 @@
+package com.example.wikiart.notifications
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "notifications")
+data class Notification(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val title: String?,
+    val message: String?,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationDao.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationDao.kt
@@ -1,0 +1,16 @@
+package com.example.wikiart.notifications
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface NotificationDao {
+    @Query("SELECT * FROM notifications ORDER BY timestamp DESC")
+    fun getAll(): LiveData<List<Notification>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(notification: Notification)
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationDatabase.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationDatabase.kt
@@ -1,0 +1,28 @@
+package com.example.wikiart.notifications
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [Notification::class], version = 1, exportSchema = false)
+abstract class NotificationDatabase : RoomDatabase() {
+    abstract fun notificationDao(): NotificationDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: NotificationDatabase? = null
+
+        fun getDatabase(context: Context): NotificationDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    NotificationDatabase::class.java,
+                    "notification_db"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/notifications/NotificationRepository.kt
@@ -1,0 +1,9 @@
+package com.example.wikiart.notifications
+
+class NotificationRepository(private val dao: NotificationDao) {
+    val notifications = dao.getAll()
+
+    suspend fun insert(notification: Notification) {
+        dao.insert(notification)
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/notifications/WikiArtFirebaseMessagingService.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/notifications/WikiArtFirebaseMessagingService.kt
@@ -1,0 +1,20 @@
+package com.example.wikiart.notifications
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class WikiArtFirebaseMessagingService : FirebaseMessagingService() {
+    override fun onMessageReceived(message: RemoteMessage) {
+        val title = message.notification?.title
+        val body = message.notification?.body
+        val notification = Notification(title = title, message = body)
+        val dao = NotificationDatabase.getDatabase(applicationContext).notificationDao()
+        val repository = NotificationRepository(dao)
+        CoroutineScope(Dispatchers.IO).launch {
+            repository.insert(notification)
+        }
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsAdapter.kt
@@ -1,0 +1,32 @@
+package com.example.wikiart.ui.notifications
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.wikiart.databinding.ItemNotificationBinding
+import com.example.wikiart.notifications.Notification
+
+class NotificationsAdapter : ListAdapter<Notification, NotificationsAdapter.ViewHolder>(DiffCallback()) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemNotificationBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ViewHolder(private val binding: ItemNotificationBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(notification: Notification) {
+            binding.notificationTitle.text = notification.title
+            binding.notificationMessage.text = notification.message
+        }
+    }
+
+    class DiffCallback : DiffUtil.ItemCallback<Notification>() {
+        override fun areItemsTheSame(oldItem: Notification, newItem: Notification): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Notification, newItem: Notification): Boolean = oldItem == newItem
+    }
+}

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsFragment.kt
@@ -4,9 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.wikiart.databinding.FragmentNotificationsBinding
 
 class NotificationsFragment : Fragment() {
@@ -28,9 +28,13 @@ class NotificationsFragment : Fragment() {
         _binding = FragmentNotificationsBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
-        val textView: TextView = binding.textNotifications
-        notificationsViewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+        val adapter = NotificationsAdapter()
+        binding.notificationsList.layoutManager = LinearLayoutManager(context)
+        binding.notificationsList.adapter = adapter
+
+        notificationsViewModel.notifications.observe(viewLifecycleOwner) { list ->
+            adapter.submitList(list)
+            binding.emptyView.visibility = if (list.isEmpty()) View.VISIBLE else View.GONE
         }
         return root
     }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/notifications/NotificationsViewModel.kt
@@ -3,13 +3,17 @@ package com.example.wikiart.ui.notifications
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import com.example.wikiart.R
+import com.example.wikiart.notifications.Notification
+import com.example.wikiart.notifications.NotificationDatabase
+import com.example.wikiart.notifications.NotificationRepository
 
 class NotificationsViewModel(application: Application) : AndroidViewModel(application) {
+    private val repository: NotificationRepository
+    val notifications: LiveData<List<Notification>>
 
-    private val _text = MutableLiveData<String>().apply {
-        value = application.getString(R.string.notifications_placeholder)
+    init {
+        val dao = NotificationDatabase.getDatabase(application).notificationDao()
+        repository = NotificationRepository(dao)
+        notifications = repository.notifications
     }
-    val text: LiveData<String> = _text
 }

--- a/WikiArt/app/src/main/res/layout/fragment_notifications.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_notifications.xml
@@ -6,17 +6,23 @@
     android:layout_height="match_parent"
     tools:context=".ui.notifications.NotificationsFragment">
 
-    <TextView
-        android:id="@+id/text_notifications"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/notifications_list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_notifications"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WikiArt/app/src/main/res/layout/item_notification.xml
+++ b/WikiArt/app/src/main/res/layout/item_notification.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/notification_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"/>
+
+    <TextView
+        android:id="@+id/notification_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="4dp"/>
+</LinearLayout>

--- a/WikiArt/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/WikiArt/app/src/main/res/menu/bottom_nav_menu.xml
@@ -17,6 +17,11 @@
         android:title="@string/title_search" />
 
     <item
+        android:id="@+id/navigation_notifications"
+        android:icon="@drawable/ic_notifications_black_24dp"
+        android:title="@string/title_notifications" />
+
+    <item
         android:id="@+id/navigation_support"
         android:icon="@drawable/baseline_help_24"
         android:title="@string/title_support" />

--- a/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
+++ b/WikiArt/app/src/main/res/navigation/mobile_navigation.xml
@@ -39,6 +39,12 @@
     </fragment>
 
     <fragment
+        android:id="@+id/navigation_notifications"
+        android:name="com.example.wikiart.ui.notifications.NotificationsFragment"
+        android:label="@string/title_notifications"
+        tools:layout="@layout/fragment_notifications" />
+
+    <fragment
         android:id="@+id/navigation_support"
         android:name="com.example.wikiart.ui.support.SupportFragment"
         android:label="@string/title_support"

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="title_artists">Artists</string>
     <string name="title_search">Search</string>
     <string name="title_support">Support</string>
+    <string name="title_notifications">Notifications</string>
     <string name="category_featured">Featured</string>
     <string name="category_popular">Popular</string>
     <string name="category_high_res">High Resolution</string>
@@ -40,7 +41,5 @@
     <string name="support_email_chooser">Send Email</string>
     <string name="support_no_email_app">No email app found</string>
     <string name="suggestions_header">Suggestions</string>
-    <string name="home_placeholder">This is home Fragment</string>
-    <string name="dashboard_placeholder">This is dashboard Fragment</string>
-    <string name="notifications_placeholder">This is notifications Fragment</string>
+    <string name="no_notifications">No notifications yet</string>
 </resources>

--- a/WikiArt/build.gradle.kts
+++ b/WikiArt/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
 }

--- a/WikiArt/gradle/libs.versions.toml
+++ b/WikiArt/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ coil = "2.5.0"
 datastore = "1.1.1"
 lifecycleRuntimeKtx = "2.9.1"
 photoView = "2.3.0"
+room = "2.6.1"
+firebaseBom = "33.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,8 +38,14 @@ coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 photoview = { group = "com.github.chrisbanes", name = "PhotoView", version.ref = "photoView" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- enable Firebase Cloud Messaging service to store incoming alerts in a Room database
- replace placeholder notifications fragment with RecyclerView of stored notifications
- expose notifications via bottom navigation and navigation graph

## Testing
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a774b557c8832eb7c36ec81d6a34c7