### PR TITLE
Add content descriptions for painting and artist images

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistAdapter.kt
@@ -50,6 +50,7 @@ class ArtistAdapter(private var layout: Layout, private val listener: ((Artist) 
 
         fun bind(artist: Artist, listener: ((Artist) -> Unit)?) {
             image.load(artist.image)
+            image.contentDescription = artist.title
             name.text = artist.title
             itemView.setOnClickListener { listener?.invoke(artist) }
         }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingAdapter.kt
@@ -53,6 +53,7 @@ class PaintingAdapter(layout: Layout, private val listener: ((Painting) -> Unit)
                 image.layoutParams = params
             }
             image.load(p.imageUrl())
+            image.contentDescription = itemView.context.getString(R.string.content_description_painting, p.title, p.artistName)
             title?.text = p.title
             artist?.text = p.artistName
             itemView.setOnClickListener { listener?.invoke(p) }

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailFragment.kt
@@ -55,6 +55,7 @@ class PaintingDetailFragment : Fragment() {
         viewModel.painting.observe(viewLifecycleOwner) { painting ->
             painting?.let {
                 binding.paintingImage.load(it.imageUrl())
+                binding.paintingImage.contentDescription = getString(R.string.content_description_painting, it.title, it.artistName)
                 binding.paintingTitle.text = it.title
                 binding.paintingArtist.text = it.artistName
                 binding.paintingYear.text = it.year

--- a/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
+++ b/WikiArt/app/src/main/res/layout/fragment_painting_detail.xml
@@ -15,7 +15,8 @@
                 android:id="@+id/paintingImage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:adjustViewBounds="true" />
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/painting_image" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/paintingTitle"

--- a/WikiArt/app/src/main/res/layout/item_artist_grid.xml
+++ b/WikiArt/app/src/main/res/layout/item_artist_grid.xml
@@ -9,7 +9,8 @@
         android:id="@+id/artistImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/artist_image" />
 
     <TextView
         android:id="@+id/artistName"

--- a/WikiArt/app/src/main/res/layout/item_artist_list.xml
+++ b/WikiArt/app/src/main/res/layout/item_artist_list.xml
@@ -9,7 +9,8 @@
         android:id="@+id/artistImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/artist_image" />
 
     <TextView
         android:id="@+id/artistName"

--- a/WikiArt/app/src/main/res/layout/item_painting_grid.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_grid.xml
@@ -9,7 +9,8 @@
         android:id="@+id/paintingImage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/painting_image" />
 
     <TextView
         android:id="@+id/paintingTitle"

--- a/WikiArt/app/src/main/res/layout/item_painting_list.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_list.xml
@@ -9,7 +9,8 @@
         android:id="@+id/paintingImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true" />
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/painting_image" />
 
     <TextView
         android:id="@+id/paintingTitle"

--- a/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
+++ b/WikiArt/app/src/main/res/layout/item_painting_sheet.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
+        android:contentDescription="@string/painting_image"
         android:scaleType="centerCrop" />
 
     <LinearLayout

--- a/WikiArt/app/src/main/res/values-es/strings.xml
+++ b/WikiArt/app/src/main/res/values-es/strings.xml
@@ -43,4 +43,7 @@
     <string name="home_placeholder">Este es el fragmento de inicio</string>
     <string name="dashboard_placeholder">Este es el fragmento del tablero</string>
     <string name="notifications_placeholder">Este es el fragmento de notificaciones</string>
+    <string name="painting_image">Imagen de pintura</string>
+    <string name="artist_image">Imagen del artista</string>
+    <string name="content_description_painting">%1$s por %2$s</string>
 </resources>

--- a/WikiArt/app/src/main/res/values-fr/strings.xml
+++ b/WikiArt/app/src/main/res/values-fr/strings.xml
@@ -43,4 +43,7 @@
     <string name="home_placeholder">Ceci est le fragment d&apos;accueil</string>
     <string name="dashboard_placeholder">Ceci est le fragment du tableau de bord</string>
     <string name="notifications_placeholder">Ceci est le fragment des notifications</string>
+    <string name="painting_image">Image de peinture</string>
+    <string name="artist_image">Image de l'artiste</string>
+    <string name="content_description_painting">%1$s par %2$s</string>
 </resources>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -42,4 +42,7 @@
     <string name="support_no_email_app">No email app found</string>
     <string name="suggestions_header">Suggestions</string>
     <string name="no_notifications">No notifications yet</string>
+    <string name="painting_image">Painting image</string>
+    <string name="artist_image">Artist image</string>
+    <string name="content_description_painting">%1$s by %2$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add contentDescription attributes to painting and artist image layouts
- set dynamic content descriptions in adapters and detail fragment
- include string resources for image descriptions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a796ef48d8832e9083aaabb34af0a3