### PR TITLE
Handle WikiArt deep links for paintings and artists

### DIFF
--- a/WikiArt/app/src/androidTest/java/com/example/wikiart/DeepLinkNavigationTest.kt
+++ b/WikiArt/app/src/androidTest/java/com/example/wikiart/DeepLinkNavigationTest.kt
@@ -1,0 +1,36 @@
+package com.example.wikiart
+
+import android.content.Intent
+import android.net.Uri
+import androidx.navigation.findNavController
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeepLinkNavigationTest {
+
+    @Test
+    fun opensPaintingLink() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.wikiart.org/en/artist/sample-painting"))
+        ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val navController = activity.findNavController(R.id.nav_host_fragment_activity_main)
+                assertEquals(R.id.paintingDetailFragment, navController.currentDestination?.id)
+            }
+        }
+    }
+
+    @Test
+    fun opensArtistLink() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.wikiart.org/en/sample-artist"))
+        ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val navController = activity.findNavController(R.id.nav_host_fragment_activity_main)
+                assertEquals(R.id.artistDetailFragment, navController.currentDestination?.id)
+            }
+        }
+    }
+}

--- a/WikiArt/app/src/main/AndroidManifest.xml
+++ b/WikiArt/app/src/main/AndroidManifest.xml
@@ -24,6 +24,24 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.wikiart.org"
+                    android:pathPattern="/.*/.*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.wikiart.org"
+                    android:pathPattern="/.*" />
+            </intent-filter>
         </activity>
         <service
             android:name=".notifications.WikiArtFirebaseMessagingService"

--- a/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.wikiart
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import androidx.appcompat.app.AppCompatActivity
@@ -8,6 +10,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.wikiart.databinding.ActivityMainBinding
+import com.example.wikiart.ui.artists.ArtistDetailFragment
+import com.example.wikiart.ui.paintings.PaintingDetailFragment
 
 class MainActivity : AppCompatActivity() {
 
@@ -37,5 +41,32 @@ class MainActivity : AppCompatActivity() {
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+
+        handleDeepLink(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handleDeepLink(intent)
+    }
+
+    private fun handleDeepLink(intent: Intent?) {
+        val data: Uri = intent?.data ?: return
+        if (data.host != "www.wikiart.org") return
+        val navController = findNavController(R.id.nav_host_fragment_activity_main)
+        val segments = data.pathSegments
+        if (segments.size >= 3) {
+            val id = segments[2]
+            val bundle = Bundle().apply {
+                putString(PaintingDetailFragment.ARG_PAINTING_ID, id)
+            }
+            navController.navigate(R.id.paintingDetailFragment, bundle)
+        } else if (segments.size >= 2) {
+            val path = "/${segments[0]}/${segments[1]}"
+            val bundle = Bundle().apply {
+                putString(ArtistDetailFragment.ARG_ARTIST_PATH, path)
+            }
+            navController.navigate(R.id.artistDetailFragment, bundle)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support opening WikiArt painting and artist URLs via intent filters
- parse incoming deep links to navigate to the appropriate detail fragment
- add instrumentation tests verifying navigation from sample URLs

## Testing
- `./gradlew test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*
- `./gradlew connectedAndroidTest` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a8bf31ec832ebf387c452eb98b5b