### PR TITLE
Add JitPack repository

### DIFF
--- a/WikiArt/settings.gradle.kts
+++ b/WikiArt/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
## Summary
- include JitPack in Gradle dependency repositories

## Testing
- `cd WikiArt && ./gradlew --refresh-dependencies`


------
https://chatgpt.com/codex/tasks/task_e_68a7adb8228c832e853941dfa65004e4