### PR TITLE
Escape apostrophe in support feedback title

### DIFF
--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="section_all">All Sections</string>
     <string name="title_painting_detail">Painting</string>
     <string name="title_artist_detail">Artist</string>
-    <string name="support_feedback_title">We'd love your feedback</string>
+    <string name="support_feedback_title">We\'d love your feedback</string>
     <string name="support_email_hint">Your email (optional)</string>
     <string name="support_message_hint">Message</string>
     <string name="support_send_feedback">Send Feedback</string>


### PR DESCRIPTION
## Summary
- Escape apostrophe in the support feedback title string resource

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a13df134832eb0cb336e60117b51