### PR TITLE
Use JSON for Room string list converter

### DIFF
--- a/WikiArt/app/src/test/java/com/example/wikiart/data/local/ConvertersTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/data/local/ConvertersTest.kt
@@ -1,0 +1,24 @@
+package com.example.wikiart.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConvertersTest {
+    private val converters = Converters()
+
+    @Test
+    fun stringListRoundTrip() {
+        val list = listOf("a", "b", "c")
+        val json = converters.fromStringList(list)
+        assertEquals("[\"a\",\"b\",\"c\"]", json)
+        assertEquals(list, converters.toStringList(json))
+    }
+
+    @Test
+    fun emptyListRoundTrip() {
+        val list = emptyList<String>()
+        val json = converters.fromStringList(list)
+        assertEquals("[]", json)
+        assertEquals(list, converters.toStringList(json))
+    }
+}


### PR DESCRIPTION
## Summary
- serialize string lists with JSON arrays instead of custom delimiter
- bump database to v2 and migrate existing search results to JSON format
- add unit tests for converter

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a737385c832e958926c07b49a84c