### PR TITLE
Invalidate stale cache entries

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
@@ -20,28 +20,23 @@ class ArtistsRepository(
     ): ArtistList {
         val cached = artistDao.getArtists(category.path, page, section)
         val now = System.currentTimeMillis()
-        if (cached.isNotEmpty() && cached.all { now - it.updated < CACHE_TIMEOUT }) {
-            val artists = cached.map { it.toModel() }
-            return ArtistList(artists, artists.size, artists.size)
-        }
-        return try {
-            val result = service.artistsByCategory(
-                language = language,
-                category = category.path,
-                page = page,
-                searchTerm = section,
-            )
-            val entities = result.Artists.map { it.toEntity(category.path, page, section, now) }
-            artistDao.insertAll(entities)
-            result
-        } catch (e: Exception) {
-            if (cached.isNotEmpty()) {
+        if (cached.isNotEmpty()) {
+            if (cached.all { now - it.updated < CACHE_TIMEOUT }) {
                 val artists = cached.map { it.toModel() }
-                ArtistList(artists, artists.size, artists.size)
+                return ArtistList(artists, artists.size, artists.size)
             } else {
-                throw e
+                artistDao.delete(category.path, page, section)
             }
         }
+        val result = service.artistsByCategory(
+            language = language,
+            category = category.path,
+            page = page,
+            searchTerm = section,
+        )
+        val entities = result.Artists.map { it.toEntity(category.path, page, section, now) }
+        artistDao.insertAll(entities)
+        return result
     }
 }
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
@@ -15,16 +15,16 @@ class PaintingDetailsRepository(
     suspend fun getPainting(id: String): Painting {
         val cached = paintingDao.getPainting(id)
         val now = System.currentTimeMillis()
-        if (cached != null && now - cached.updated < CACHE_TIMEOUT) {
-            return cached.toModel()
+        if (cached != null) {
+            if (now - cached.updated < CACHE_TIMEOUT) {
+                return cached.toModel()
+            } else {
+                paintingDao.delete(id)
+            }
         }
-        return try {
-            val network = service.paintingDetails(language, id)
-            paintingDao.insert(network.toEntity(now))
-            network
-        } catch (e: Exception) {
-            cached?.toModel() ?: throw e
-        }
+        val network = service.paintingDetails(language, id)
+        paintingDao.insert(network.toEntity(now))
+        return network
     }
 }
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
@@ -25,16 +25,16 @@ class SearchRepository(
     suspend fun autocomplete(term: String): AutocompleteResult {
         val cached = searchDao.get(term)
         val now = System.currentTimeMillis()
-        if (cached != null && now - cached.updated < CACHE_TIMEOUT) {
-            return cached.toModel()
+        if (cached != null) {
+            if (now - cached.updated < CACHE_TIMEOUT) {
+                return cached.toModel()
+            } else {
+                searchDao.delete(term)
+            }
         }
-        return try {
-            val result = service.autocomplete(language = language, term = term)
-            searchDao.insert(result.toEntity(term, now))
-            result
-        } catch (e: Exception) {
-            cached?.toModel() ?: throw e
-        }
+        val result = service.autocomplete(language = language, term = term)
+        searchDao.insert(result.toEntity(term, now))
+        return result
     }
 }
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/data/local/WikiArtDatabase.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/data/local/WikiArtDatabase.kt
@@ -75,6 +75,9 @@ interface PaintingDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(painting: PaintingEntity)
+
+    @Query("DELETE FROM paintings WHERE id = :id")
+    suspend fun delete(id: String)
 }
 
 @Dao
@@ -84,6 +87,9 @@ interface ArtistDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(artists: List<ArtistEntity>)
+
+    @Query("DELETE FROM artists WHERE category = :category AND page = :page AND ((section IS NULL AND :section IS NULL) OR section = :section)")
+    suspend fun delete(category: String, page: Int, section: String?)
 }
 
 @Dao
@@ -93,6 +99,9 @@ interface SearchResultDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(result: SearchResultEntity)
+
+    @Query("DELETE FROM search_results WHERE query = :query")
+    suspend fun delete(query: String)
 }
 
 @Database(

--- a/WikiArt/app/src/test/java/com/example/wikiart/api/ArtistsRepositoryTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/api/ArtistsRepositoryTest.kt
@@ -1,0 +1,49 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.data.local.ArtistDao
+import com.example.wikiart.data.local.CACHE_TIMEOUT
+import com.example.wikiart.data.local.ArtistEntity
+import com.example.wikiart.data.local.toEntity
+import com.example.wikiart.model.Artist
+import com.example.wikiart.model.ArtistCategory
+import com.example.wikiart.model.ArtistList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistsRepositoryTest {
+
+    private class FakeArtistDao(initial: List<ArtistEntity>) : ArtistDao {
+        var list: List<ArtistEntity> = initial
+        var deleted = false
+        override suspend fun getArtists(category: String, page: Int, section: String?): List<ArtistEntity> = list
+        override suspend fun insertAll(artists: List<ArtistEntity>) { list = artists }
+        override suspend fun delete(category: String, page: Int, section: String?) { deleted = true; list = emptyList() }
+    }
+
+    private class Service : FakeWikiArtService() {
+        var calls = 0
+        override suspend fun artistsByCategory(language: String, category: String, page: Int, json: Int, layout: String, searchTerm: String?): ArtistList {
+            calls++
+            val artist = Artist("net", "title", null, null, null, null, null)
+            return ArtistList(listOf(artist), 1, 1)
+        }
+    }
+
+    @Test
+    fun staleArtistsAreRefreshed() = runBlocking {
+        val now = System.currentTimeMillis()
+        val stale = now - CACHE_TIMEOUT - 1
+        val cachedArtist = Artist("id", "title", null, null, null, null, null)
+        val dao = FakeArtistDao(listOf(cachedArtist.toEntity(ArtistCategory.POPULAR.path, 1, null, stale)))
+        val service = Service()
+        val repo = ArtistsRepository(artistDao = dao, service = service)
+
+        val result = repo.getArtists(ArtistCategory.POPULAR, 1)
+
+        assertEquals(1, service.calls)
+        assertTrue(dao.deleted)
+        assertEquals("net", result.Artists[0].id)
+    }
+}

--- a/WikiArt/app/src/test/java/com/example/wikiart/api/FakeWikiArtService.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/api/FakeWikiArtService.kt
@@ -1,0 +1,44 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.model.*
+
+open class FakeWikiArtService : WikiArtService {
+    override suspend fun popularPaintings(language: String, page: Int, json: Int): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun paintingsByCategory(language: String, param: String, page: Int, json: Int): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun paintingDetails(language: String, id: String): Painting =
+        throw NotImplementedError()
+
+    override suspend fun relatedPaintings(path: String, json: Int): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun artistDetails(path: String, json: Int): ArtistDetails =
+        throw NotImplementedError()
+
+    override suspend fun artistPaintings(path: String, json: Int, page: Int): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun artistsByCategory(language: String, category: String, page: Int, json: Int, layout: String, searchTerm: String?): ArtistList =
+        throw NotImplementedError()
+
+    override suspend fun artistSections(language: String, category: String, json: Int): ArtistSections =
+        throw NotImplementedError()
+
+    override suspend fun paintingSections(language: String, group: Int): List<PaintingSection> =
+        throw NotImplementedError()
+
+    override suspend fun paintingsBySection(language: String, dictIdsJson: String, page: Int, json: Int): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun searchPaintings(language: String, term: String, page: Int, json: Int, layout: String): PaintingList =
+        throw NotImplementedError()
+
+    override suspend fun searchArtists(language: String, term: String, page: Int, json: Int, layout: String): ArtistList =
+        throw NotImplementedError()
+
+    override suspend fun autocomplete(language: String, term: String, json: Int): AutocompleteResult =
+        throw NotImplementedError()
+}

--- a/WikiArt/app/src/test/java/com/example/wikiart/api/PaintingDetailsRepositoryTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/api/PaintingDetailsRepositoryTest.kt
@@ -1,0 +1,46 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.data.local.CACHE_TIMEOUT
+import com.example.wikiart.data.local.PaintingDao
+import com.example.wikiart.data.local.PaintingEntity
+import com.example.wikiart.data.local.toEntity
+import com.example.wikiart.model.Painting
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaintingDetailsRepositoryTest {
+
+    private class FakePaintingDao(initial: PaintingEntity?) : PaintingDao {
+        var entity: PaintingEntity? = initial
+        var deleted = false
+        override suspend fun getPainting(id: String): PaintingEntity? = entity
+        override suspend fun insert(painting: PaintingEntity) { entity = painting }
+        override suspend fun delete(id: String) { deleted = true; entity = null }
+    }
+
+    private class Service : FakeWikiArtService() {
+        var calls = 0
+        override suspend fun paintingDetails(language: String, id: String): Painting {
+            calls++
+            return Painting(id, "net", "", 0, 0, "artist", "img", "url", null, 0)
+        }
+    }
+
+    @Test
+    fun stalePaintingIsRefreshed() = runBlocking {
+        val now = System.currentTimeMillis()
+        val stale = now - CACHE_TIMEOUT - 1
+        val cachedModel = Painting("1", "cached", "", 0, 0, "artist", "img", "url", null, 0)
+        val dao = FakePaintingDao(cachedModel.toEntity(stale))
+        val service = Service()
+        val repo = PaintingDetailsRepository(service = service, paintingDao = dao)
+
+        val result = repo.getPainting("1")
+
+        assertEquals("net", result.title)
+        assertTrue(dao.deleted)
+        assertEquals(1, service.calls)
+    }
+}

--- a/WikiArt/app/src/test/java/com/example/wikiart/api/SearchRepositoryTest.kt
+++ b/WikiArt/app/src/test/java/com/example/wikiart/api/SearchRepositoryTest.kt
@@ -1,0 +1,46 @@
+package com.example.wikiart.api
+
+import com.example.wikiart.data.local.CACHE_TIMEOUT
+import com.example.wikiart.data.local.SearchResultDao
+import com.example.wikiart.data.local.SearchResultEntity
+import com.example.wikiart.data.local.toEntity
+import com.example.wikiart.model.AutocompleteResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchRepositoryTest {
+
+    private class FakeSearchDao(initial: SearchResultEntity?) : SearchResultDao {
+        var entity: SearchResultEntity? = initial
+        var deleted = false
+        override suspend fun get(query: String): SearchResultEntity? = entity
+        override suspend fun insert(result: SearchResultEntity) { entity = result }
+        override suspend fun delete(query: String) { deleted = true; entity = null }
+    }
+
+    private class Service : FakeWikiArtService() {
+        var calls = 0
+        override suspend fun autocomplete(language: String, term: String, json: Int): AutocompleteResult {
+            calls++
+            return AutocompleteResult(listOf("net"))
+        }
+    }
+
+    @Test
+    fun staleAutocompleteIsRefreshed() = runBlocking {
+        val now = System.currentTimeMillis()
+        val stale = now - CACHE_TIMEOUT - 1
+        val cached = AutocompleteResult(listOf("old"))
+        val dao = FakeSearchDao(cached.toEntity("term", stale))
+        val service = Service()
+        val repo = SearchRepository(service = service, searchDao = dao)
+
+        val result = repo.autocomplete("term")
+
+        assertEquals(listOf("net"), result.terms)
+        assertTrue(dao.deleted)
+        assertEquals(1, service.calls)
+    }
+}


### PR DESCRIPTION
## Summary
- add delete operations to WikiArtDatabase DAOs
- drop outdated cache entries before using, forcing refresh from network
- add unit tests ensuring stale data triggers refresh

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a73ca3e4832e9b2a3cf1ebf521ec