### PR TITLE
Escape apostrophes in Android string resources

### DIFF
--- a/WikiArt/app/src/main/res/values-fr/strings.xml
+++ b/WikiArt/app/src/main/res/values-fr/strings.xml
@@ -44,6 +44,6 @@
     <string name="dashboard_placeholder">Ceci est le fragment du tableau de bord</string>
     <string name="notifications_placeholder">Ceci est le fragment des notifications</string>
     <string name="painting_image">Image de peinture</string>
-    <string name="artist_image">Image de l'artiste</string>
+    <string name="artist_image">Image de l&apos;artiste</string>
     <string name="content_description_painting">%1$s par %2$s</string>
 </resources>

--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="section_all">All Sections</string>
     <string name="title_painting_detail">Painting</string>
     <string name="title_artist_detail">Artist</string>
-    <string name="support_feedback_title">We\'d love your feedback</string>
+    <string name="support_feedback_title">We&apos;d love your feedback</string>
     <string name="support_email_hint">Your email (optional)</string>
     <string name="support_message_hint">Message</string>
     <string name="support_send_feedback">Send Feedback</string>


### PR DESCRIPTION
## Summary
- escape apostrophes in English and French string resources to prevent Unicode escape compilation issues

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8acb0d9b0832eb3780d4956adf9bc