### PR TITLE
Fix feedback title string escaping

### DIFF
--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="section_all">All Sections</string>
     <string name="title_painting_detail">Painting</string>
     <string name="title_artist_detail">Artist</string>
-    <string name="support_feedback_title">We\'d love your feedback</string>
+    <string name="support_feedback_title">We'd love your feedback</string>
     <string name="support_email_hint">Your email (optional)</string>
     <string name="support_message_hint">Message</string>
     <string name="support_send_feedback">Send Feedback</string>


### PR DESCRIPTION
## Summary
- fix escaping in feedback title string resource

## Testing
- `./gradlew assembleDebug` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ac9e76cc832eaa2f744afa1f7547