### PR TITLE
Remove unused toModel import

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ArtistsRepository.kt
@@ -4,7 +4,6 @@ import com.example.wikiart.WikiArtApplication
 import com.example.wikiart.data.local.CACHE_TIMEOUT
 import com.example.wikiart.data.local.ArtistDao
 import com.example.wikiart.data.local.toEntity
-import com.example.wikiart.data.local.toModel
 import com.example.wikiart.model.ArtistCategory
 import com.example.wikiart.model.ArtistList
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/PaintingDetailsRepository.kt
@@ -4,7 +4,6 @@ import com.example.wikiart.WikiArtApplication
 import com.example.wikiart.data.local.CACHE_TIMEOUT
 import com.example.wikiart.data.local.PaintingDao
 import com.example.wikiart.data.local.toEntity
-import com.example.wikiart.data.local.toModel
 import com.example.wikiart.model.Painting
 
 class PaintingDetailsRepository(

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/SearchRepository.kt
@@ -4,7 +4,6 @@ import com.example.wikiart.WikiArtApplication
 import com.example.wikiart.data.local.CACHE_TIMEOUT
 import com.example.wikiart.data.local.SearchResultDao
 import com.example.wikiart.data.local.toEntity
-import com.example.wikiart.data.local.toModel
 import com.example.wikiart.model.ArtistList
 import com.example.wikiart.model.AutocompleteResult
 import com.example.wikiart.model.PaintingList


### PR DESCRIPTION
## Summary
- remove toModel imports from repositories

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b013b95c832e9905c0631e804818