### PR TITLE
Use compile-time constant for cache timeout

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/data/local/WikiArtDatabase.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/data/local/WikiArtDatabase.kt
@@ -8,9 +8,8 @@ import com.example.wikiart.model.Artist
 import com.example.wikiart.model.AutocompleteResult
 import com.example.wikiart.model.Painting
 import org.json.JSONArray
-import java.util.concurrent.TimeUnit
 
-const val CACHE_TIMEOUT: Long = TimeUnit.HOURS.toMillis(1)
+const val CACHE_TIMEOUT: Long = 60L * 60L * 1000L
 
 @Entity(tableName = "paintings")
 data class PaintingEntity(


### PR DESCRIPTION
## Summary
- replace TimeUnit-based cache timeout with compile-time constant

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b01605cc832eb320edb1eb513c61