### PR TITLE
Rename PaintingSection Content property

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/PaintingSection.kt
@@ -5,7 +5,7 @@ package com.example.wikiart.model
  */
 data class PaintingSection(
     val _id: Id,
-    val Content: Content,
+    val content: Content,
 ) {
     data class Id(val _oid: String)
     data class Content(val Title: TitleContent) {
@@ -24,9 +24,9 @@ data class PaintingSection(
     val title: String
         get() {
             val lang = com.example.wikiart.api.getLanguage()
-            return Content.Title.Title[lang]
-                ?: Content.Title.Title["en"]
-                ?: Content.Title.Title.values.firstOrNull().orEmpty()
+            return content.Title.Title[lang]
+                ?: content.Title.Title["en"]
+                ?: content.Title.Title.values.firstOrNull().orEmpty()
         }
 }
 


### PR DESCRIPTION
## Summary
- Rename `Content` property to `content` in `PaintingSection` to distinguish it from the nested `Content` class
- Update localized title accessors to use new `content` property name

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b0175788832ea44e9e4fd29c6df9