### PR TITLE
Add placeholder strings for fragments

### DIFF
--- a/WikiArt/app/src/main/res/values/strings.xml
+++ b/WikiArt/app/src/main/res/values/strings.xml
@@ -41,6 +41,9 @@
     <string name="support_email_chooser">Send Email</string>
     <string name="support_no_email_app">No email app found</string>
     <string name="suggestions_header">Suggestions</string>
+    <string name="home_placeholder">This is the home fragment</string>
+    <string name="dashboard_placeholder">This is the dashboard fragment</string>
+    <string name="notifications_placeholder">This is the notifications fragment</string>
     <string name="no_notifications">No notifications yet</string>
     <string name="painting_image">Painting image</string>
     <string name="artist_image">Artist image</string>


### PR DESCRIPTION
## Summary
- add placeholder string resources for home, dashboard, and notifications fragments

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b01b8b44832e8f47c6bd59565075