### PR TITLE
Fix repository constructor calls with named args

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/artists/ArtistListViewModel.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.launch
 class ArtistListViewModel(
     private val language: String = getLanguage(),
 ) : ViewModel() {
-    private val repository = ArtistsRepository(language)
-    private val categoryRepository = ArtistsCategoryRepository(language)
+    private val repository = ArtistsRepository(language = language)
+    private val categoryRepository = ArtistsCategoryRepository(language = language)
 
     private val _artists = MutableLiveData<List<Artist>>(emptyList())
     val artists: LiveData<List<Artist>> = _artists

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingDetailViewModel.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.launch
 class PaintingDetailViewModel(
     private val paintingId: String,
     private val language: String = getLanguage(),
-    private val detailsRepository: PaintingDetailsRepository = PaintingDetailsRepository(language),
+    private val detailsRepository: PaintingDetailsRepository =
+        PaintingDetailsRepository(language = language),
     private val relatedRepository: RelatedPaintingsRepository = RelatedPaintingsRepository(),
 ) : ViewModel() {
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/paintings/PaintingListViewModel.kt
@@ -35,7 +35,7 @@ class PaintingListViewModel(
     var layout: PaintingAdapter.Layout = PaintingAdapter.Layout.LIST
         private set
 
-    private val sectionsRepository = PaintingSectionsRepository(language)
+    private val sectionsRepository = PaintingSectionsRepository(language = language)
     private val _sections = MutableLiveData<List<PaintingSection>>(emptyList())
     val sections: LiveData<List<PaintingSection>> = _sections
 

--- a/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/ui/search/SearchViewModel.kt
@@ -17,7 +17,7 @@ class SearchViewModel(
     application: Application,
     private val language: String = getLanguage(),
 ) : AndroidViewModel(application) {
-    private val repository = SearchRepository(language)
+    private val repository = SearchRepository(language = language)
     private val resources = application.resources
 
     private val paintings = mutableListOf<Painting>()


### PR DESCRIPTION
## Summary
- Use named `language` argument when instantiating repositories in view models
- Ensure repository constructors receive correct WikiArtService and language

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b01c8374832ea53d523c949711ad