### PR TITLE
Rename Url property to rawUrl in ArtistSection model

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistSection.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/model/ArtistSection.kt
@@ -1,17 +1,19 @@
 package com.example.wikiart.model
 
+import com.squareup.moshi.Json
 import java.io.Serializable
 
 /**
  * Represents a section within an artist category returned by the API.
  */
 data class ArtistSection(
-    val Url: String,
+    @field:Json(name = "Url")
+    val rawUrl: String,
     val Title: String,
     val Count: Int
 ) : Serializable {
     val url: String
-        get() = Url.substringAfterLast('/')
+        get() = rawUrl.substringAfterLast('/')
 }
 
 /**


### PR DESCRIPTION
## Summary
- rename ArtistSection's `Url` property to `rawUrl`
- map JSON field `Url` with Moshi annotation
- derive `url` from new `rawUrl`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b5a0e8b8832ea9538ab347d09242