### PR TITLE
Add Moshi Kotlin adapter for Retrofit

### DIFF
--- a/WikiArt/app/build.gradle.kts
+++ b/WikiArt/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.retrofit2)
     implementation(libs.converter.moshi)
+    implementation(libs.moshi.kotlin)
     implementation(libs.coil)
     implementation(libs.photoview)
     implementation(libs.androidx.datastore.preferences)

--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ApiClient.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ApiClient.kt
@@ -1,5 +1,7 @@
 package com.example.wikiart.api
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
@@ -8,10 +10,14 @@ object ApiClient {
 
     var serviceOverride: WikiArtService? = null
 
+    private val moshi: Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
     private val defaultService: WikiArtService by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
             .create(WikiArtService::class.java)
     }

--- a/WikiArt/gradle/libs.versions.toml
+++ b/WikiArt/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ lifecycleRuntimeKtx = "2.9.1"
 photoView = "2.3.0"
 room = "2.6.1"
 firebaseBom = "33.3.0"
+moshi = "1.15.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,7 @@ androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navi
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
+moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 photoview = { group = "io.github.chrisbanes", name = "PhotoView", version.ref = "photoView" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
## Summary
- add moshi-kotlin version and library definitions
- hook up moshi-kotlin dependency in app module
- configure ApiClient Moshi instance with KotlinJsonAdapterFactory

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bcf2bc54832e9a9026001f654f5a