### PR TITLE
Ensure WikiArt API base URL ends with slash

### DIFF
--- a/WikiArt/app/src/main/java/com/example/wikiart/api/ApiClient.kt
+++ b/WikiArt/app/src/main/java/com/example/wikiart/api/ApiClient.kt
@@ -4,7 +4,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object ApiClient {
-    private const val BASE_URL = "https://www.wikiart.org"
+    private const val BASE_URL = "https://www.wikiart.org/"
 
     var serviceOverride: WikiArtService? = null
 


### PR DESCRIPTION
## Summary
- add trailing slash to BASE_URL in `ApiClient`

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bcf51608832eacec5b554886daf3